### PR TITLE
refactor: unify clue if-checks under is_playable_square helper

### DIFF
--- a/parse/src/parser/grids.rs
+++ b/parse/src/parser/grids.rs
@@ -94,16 +94,21 @@ fn validate_grid_consistency(
     Ok(())
 }
 
+/// Returns `true` when a cell is playable, i.e. it holds either an empty
+/// square (`FREE_SQUARE`) or letter/number content, as opposed to a blocked
+/// square (`TAKEN_SQUARE`).
+///
+/// `None` (a cell outside the grid) is treated as not playable.
+pub(crate) fn is_playable_square(cell: Option<char>) -> bool {
+    matches!(cell, Some(c) if c == FREE_SQUARE || c.is_ascii_alphanumeric())
+}
+
 pub(crate) fn cell_needs_across_clue(grid: &[String], row: usize, col: usize) -> bool {
     if let Some(row_str) = grid.get(row) {
-        if let Some(this_char) = row_str.chars().nth(col) {
-            if this_char == FREE_SQUARE || this_char.is_ascii_alphanumeric() {
-                if let Some(next_char) = row_str.chars().nth(col + 1) {
-                    if next_char != TAKEN_SQUARE || next_char.is_ascii_alphanumeric() {
-                        return col == 0 || row_str.chars().nth(col - 1) == Some(TAKEN_SQUARE);
-                    }
-                }
-            }
+        if is_playable_square(row_str.chars().nth(col))
+            && is_playable_square(row_str.chars().nth(col + 1))
+        {
+            return col == 0 || row_str.chars().nth(col - 1) == Some(TAKEN_SQUARE);
         }
     }
     false
@@ -111,18 +116,11 @@ pub(crate) fn cell_needs_across_clue(grid: &[String], row: usize, col: usize) ->
 
 pub(crate) fn cell_needs_down_clue(grid: &[String], row: usize, col: usize) -> bool {
     if let Some(row_str) = grid.get(row) {
-        if let Some(this_char) = row_str.chars().nth(col) {
-            if this_char == FREE_SQUARE || this_char.is_ascii_alphanumeric() {
-                if let Some(next_row) = grid.get(row + 1) {
-                    if let Some(next_char) = next_row.chars().nth(col) {
-                        if next_char != TAKEN_SQUARE || next_char.is_ascii_alphanumeric() {
-                            return row == 0
-                                || grid.get(row - 1).and_then(|r| r.chars().nth(col))
-                                    == Some(TAKEN_SQUARE);
-                        }
-                    }
-                }
-            }
+        if is_playable_square(row_str.chars().nth(col))
+            && is_playable_square(grid.get(row + 1).and_then(|r| r.chars().nth(col)))
+        {
+            return row == 0
+                || grid.get(row - 1).and_then(|r| r.chars().nth(col)) == Some(TAKEN_SQUARE);
         }
     }
     false
@@ -325,6 +323,31 @@ mod tests {
         // Test empty string
         let result = string_to_grid("", 1);
         assert_eq!(result, Vec::<String>::new());
+    }
+
+    /// Test is_playable_square helper
+    /// A cell is playable when it is an empty square or letter/number content,
+    /// but not a blocked square or off the grid.
+    #[test]
+    fn test_is_playable_square() {
+        // Empty square is playable
+        assert!(is_playable_square(Some(FREE_SQUARE)));
+
+        // Letters and numbers are playable
+        assert!(is_playable_square(Some('A')));
+        assert!(is_playable_square(Some('z')));
+        assert!(is_playable_square(Some('0')));
+        assert!(is_playable_square(Some('9')));
+
+        // Blocked square is not playable
+        assert!(!is_playable_square(Some(TAKEN_SQUARE)));
+
+        // Other non-alphanumeric characters are not playable
+        assert!(!is_playable_square(Some(' ')));
+        assert!(!is_playable_square(Some('#')));
+
+        // A cell outside the grid is not playable
+        assert!(!is_playable_square(None));
     }
 
     /// Test cell_needs_across_clue function


### PR DESCRIPTION
## What

Extracts the duplicated "is this cell playable" check shared by `cell_needs_across_clue` and `cell_needs_down_clue` into a single `is_playable_square(Option<char>)` helper, and replaces the nested `if let` pyramids in both functions with calls to it.

## Details

- New `is_playable_square` helper: a cell is playable when it is an empty square (`FREE_SQUARE`) or alphanumeric content, and not a blocked square (`TAKEN_SQUARE`) or off the grid (`None`).
- Both clue functions now use the helper for the current cell and the next cell.
- Added a `test_is_playable_square` test suite covering empty squares, letters/digits, blocked squares, other non-alphanumeric chars, and off-grid `None`.

## Note on behavior

The original next-cell check was `next_char != TAKEN_SQUARE || next_char.is_ascii_alphanumeric()`, where the `||` branch is dead logic. Unifying under `is_playable_square` uses the stricter `== FREE_SQUARE || is_ascii_alphanumeric()` form. These differ only for junk characters (e.g. spaces, `#`) that never appear in a valid `.puz` grid, so behavior is unchanged on real input.

## Verification

- `cargo clippy --all --all-targets -- -D warnings -D clippy::all` — clean
- `cargo test --all` — 64 passed, 6 doc-tests passed
- `cargo fmt --all -- --check` — clean