### PR TITLE
ci: bump actions/checkout to v7 across workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,7 +17,7 @@ jobs:
     name: security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: security audit
         uses: rustsec/audit-check@v2.0.0
         with:
@@ -31,7 +31,7 @@ jobs:
     # on the weekly schedule and manual dispatch, not on push/pull_request.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
       - name: cache cargo tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - os: ubuntu-latest
             rust: "1.78.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 45
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install rust
         uses: dtolnay/rust-toolchain@nightly
       - name: cache dependencies
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
       - name: cache dependencies
@@ -129,7 +129,7 @@ jobs:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           - target: aarch64-apple-darwin
             archive: zip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Compile and release
         uses: rust-build/rust-build.action@v1.4.5
         env:


### PR DESCRIPTION
## What

Updates all `actions/checkout` pins from `@v4` to `@v7` across `ci.yml`, `audit.yml`, and `release.yml` (8 occurrences).

## Why

`actions/checkout@v4` runs on the Node 20 runtime, which is being phased out. v5+ moved to Node 24; v7 is the current latest. This repo uses plain `pull_request` triggers on GitHub-hosted runners, so the v6/v7 fork-credential-hardening changes don't affect it.

## Audit of the other actions (left as-is, already current)

| Action | Pin | Status |
|---|---|---|
| `Swatinem/rust-cache` | `@v2` | Floating major already tracks latest 2.9.1 |
| `rustsec/audit-check` | `@v2.0.0` | Already latest |
| `rust-build/rust-build.action` | `@v1.4.5` | Already latest |
| `dtolnay/rust-toolchain` | `@master` / `@stable` / `@nightly` | Matches the action's documented usage; `@master` with a `toolchain:` matrix input is the officially recommended pattern |

## Verification

- `actionlint` — clean on all three workflow files

## Note

The Rust *library* (`puz-parse`) is still not published to crates.io by any workflow; the release flow only builds CLI binaries. Adding a `cargo publish` / `release-plz` step could be a good follow-up, but is out of scope for this version-bump PR.