### PR TITLE
ci: add crates.io publish workflow via trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,40 @@ name: publish
 on:
   push:
     tags: ['v*']
+    branches: [main]
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Validates that both crates package and build cleanly for release on every
+  # push to main, without publishing anything. Needs no crates.io auth because
+  # `--dry-run` aborts before upload. Catches packaging/metadata/build
+  # regressions long before an actual `v*` release tag is cut.
+  dry-run:
+    name: publish dry run
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: install rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: dry-run publish puz-parse
+        run: cargo publish -p puz-parse --dry-run
+      - name: dry-run publish puz
+        run: cargo publish -p puz --dry-run
+
   publish:
     name: publish to crates.io
+    # Publishing is strictly tag-driven: only a `v*` tag push publishes. A push
+    # to main or a manual workflow_dispatch runs the dry-run job only.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Trusted Publishing must be configured on crates.io for both the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: publish to crates.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Trusted Publishing must be configured on crates.io for both the
+    # `puz-parse` and `puz` crates, pointing at this repo + workflow.
+    environment: release
+    permissions:
+      id-token: write # required for OIDC token exchange with crates.io
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: install rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@v2
+      # `puz` depends on `puz-parse`, so the library must be published first
+      # and be available on crates.io before the CLI can resolve it.
+      - name: authenticate to crates.io (puz-parse)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth-parse
+      - name: publish puz-parse
+        run: cargo publish -p puz-parse
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-parse.outputs.token }}
+      - name: authenticate to crates.io (puz)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth-cli
+      - name: publish puz
+        run: cargo publish -p puz
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-cli.outputs.token }}


### PR DESCRIPTION
## What

Adds `.github/workflows/publish.yml` that publishes the workspace crates to crates.io on `v*` tag pushes, using **OIDC Trusted Publishing** (no long-lived `CARGO_REGISTRY_TOKEN` secret).

## How it works

- Triggers on `push` of tags matching `v*` (plus `workflow_dispatch` for manual runs)
- `permissions: id-token: write` + `rust-lang/crates-io-auth-action@v1` mints a short-lived, crate-scoped token
- Publishes **`puz-parse` first, then `puz`** \u2014 the CLI depends on the library, so the lib must be on crates.io before the CLI can resolve it
- Uses `environment: release` for an extra approval/protection layer

This follows the pattern documented by crates.io itself for Trusted Publishing.

## \u26a0\ufe0f Required one-time manual setup (maintainer)

Before this workflow can publish, Trusted Publishing must be configured **on crates.io** for **both** crates:

1. Go to crates.io \u2192 each crate (`puz-parse` and `puz`) \u2192 Settings \u2192 Trusted Publishing
2. Add a GitHub publisher: repository `mwln/puz.rs`, workflow `publish.yml`, environment `release`
3. (Optional) Create a `release` environment in repo Settings \u2192 Environments for approval gating

Without this setup, the OIDC token exchange will fail.

## Verification

- `actionlint` \u2014 clean
- `cargo publish -p puz-parse --dry-run` \u2014 packages + verify-builds successfully
- `cargo publish -p puz --dry-run` \u2014 packages + verify-builds successfully (resolves `puz-parse` from crates.io)

## Note

Both crates are already published at `0.1.2`. crates.io rejects republishing an existing version, so this workflow takes effect on the **next** version bump (e.g. tagging `v0.1.3` after bumping the crate versions). It will no-op/fail if run against an already-published version.