### PR TITLE
chore: finalize release flow (CI publish + tag-driven CLI binaries)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,57 @@
 name: release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  release:
-    name: release ${{ matrix.target }}
+  # Create the GitHub Release for the pushed tag. upload-assets attaches the
+  # prebuilt CLI binaries to it.
+  create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create the GitHub Release
+    steps:
+      - uses: actions/checkout@v7
+      - uses: taiki-e/create-gh-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build and upload prebuilt binaries of the `puz` CLI only (the puz-parse
+  # library has no binary). crates.io publishing is handled separately by
+  # publish.yml.
+  upload-assets:
+    needs: create-release
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            archive: tar.gz
+            os: ubuntu-latest
           - target: x86_64-unknown-linux-musl
-            archive: tar.gz tar.xz tar.zst
+            os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
-            archive: zip
+            os: windows-latest
           - target: x86_64-apple-darwin
-            archive: zip
+            os: macos-latest
           - target: aarch64-apple-darwin
-            archive: zip
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # to upload assets to the GitHub Release
     steps:
       - uses: actions/checkout@v7
-      - name: Compile and release
-        uses: rust-build/rust-build.action@v1.4.5
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: puz
+          target: ${{ matrix.target }}
+          include: README.md,LICENSE,cli/README.md
+          checksum: sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          RUSTTARGET: ${{ matrix.target }}
-          ARCHIVE_TYPES: ${{ matrix.archive }}
-          EXTRA_FILES: "README.md LICENSE cli/README.md"

--- a/release.toml
+++ b/release.toml
@@ -7,7 +7,10 @@ push = true
 allow-branch = ["main"]
 
 # ci
-publish = true # allows `cargo-release` to handle crates.io publishing
+# Publishing is handled in CI by .github/workflows/publish.yml, which runs
+# `cargo publish` via crates.io Trusted Publishing (OIDC) when a `v*` tag is
+# pushed. cargo-release only bumps versions, commits, tags, and pushes the tag.
+publish = false
 verify = true
 consolidate-commits = true
 


### PR DESCRIPTION
## What

Finalizes the release pipeline so a single `cargo release` tag drives everything.

### 1. `release.toml`: `publish = false`
cargo-release no longer publishes locally. It only bumps versions, commits, tags, and pushes. Publishing is done in CI (avoids a double-publish collision with publish.yml).

### 2. `release.yml`: rebuilt for tag-driven CLI binaries
Replaced `rust-build/rust-build.action` (needed a pre-existing GitHub Release; limited target support) with `taiki-e/create-gh-release-action` + `taiki-e/upload-rust-binary-action`:
- Triggers on `v*` tag push (matches publish.yml + cargo-release)
- `create-release` makes the GitHub Release; `upload-assets` builds & attaches the **`puz` CLI** binary for all 5 targets
- Only the CLI is shipped as a binary (the puz-parse library has none)

## Resulting release flow

```
cargo release <level> --execute
  -> bumps versions, commits, tags vX.Y.Z, pushes
     tag push fans out to:
       publish.yml  -> cargo publish puz-parse + puz (crates.io, OIDC)
       release.yml  -> build puz CLI binaries + GitHub Release with archives
```

## Verification
- actionlint clean on release.yml
- include files (README.md, LICENSE, cli/README.md) confirmed present

## Prereq
crates.io Trusted Publishing must be configured for both crates before publish.yml can succeed.