### PR TITLE
ci: fix duplicate README in release archive on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,11 @@ jobs:
         with:
           bin: puz
           target: ${{ matrix.target }}
-          include: README.md,LICENSE,cli/README.md
+          # Only the CLI's own README + license. Do not include the root
+          # README.md as well: the action flattens paths, so root README.md and
+          # cli/README.md would collide as `README.md` in the archive, which
+          # `7z` (Windows) rejects as a duplicate filename.
+          include: cli/README.md,LICENSE
           checksum: sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,15 @@ name: release
 on:
   push:
     tags: ['v*']
+  # Manual re-run to (re)build and upload CLI binaries for an existing tag,
+  # e.g. to backfill a target whose upload previously failed. The release for
+  # the tag must already exist; this only uploads assets to it.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build and upload binaries for (e.g. v0.1.3)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -11,9 +20,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Create the GitHub Release for the pushed tag. upload-assets attaches the
-  # prebuilt CLI binaries to it.
+  # Create the GitHub Release for the pushed tag. Skipped on manual dispatch
+  # because the release already exists in that case.
   create-release:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write # to create the GitHub Release
@@ -27,7 +37,10 @@ jobs:
   # library has no binary). crates.io publishing is handled separately by
   # publish.yml.
   upload-assets:
+    # Wait for create-release on tag pushes; on manual dispatch it is skipped,
+    # so don't require it to have succeeded.
     needs: create-release
+    if: always() && (github.event_name == 'workflow_dispatch' || needs.create-release.result == 'success')
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +60,8 @@ jobs:
       contents: write # to upload assets to the GitHub Release
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: puz
@@ -57,5 +72,7 @@ jobs:
           # `7z` (Windows) rejects as a duplicate filename.
           include: cli/README.md,LICENSE
           checksum: sha256
+          # On manual dispatch, upload to the specified existing tag's release.
+          ref: ${{ github.event.inputs.tag && format('refs/tags/{0}', github.event.inputs.tag) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The v0.1.3 release's `x86_64-pc-windows-msvc` job failed:

```
7z a puz-x86_64-pc-windows-msvc.zip puz.exe README.md LICENSE README.md
ERROR: Duplicate filename on disk: README.md
```

`release.yml` had `include: README.md,LICENSE,cli/README.md`. `upload-rust-binary-action` flattens paths, so both the root `README.md` and `cli/README.md` landed as `README.md` in the archive root. `tar`/`zip` on unix silently tolerated the duplicate (those 4 targets passed), but `7z` on Windows rejects it \u2014 so only the Windows target failed.

## Fix

Include only `cli/README.md` (the CLI's own docs) + `LICENSE`. The root workspace README isn't useful inside a CLI binary archive anyway.

## Note on v0.1.3

v0.1.3 already published to crates.io (both crates, immutable) and its GitHub Release has 4/5 binaries. The Windows `.zip` is being attached separately. This fix ensures all 5 targets succeed from v0.1.4 onward.

## Verification
- actionlint clean