### PR TITLE
docs: restructure and align README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,108 @@
-# puz.rs
+# puz.rs - A Rust-powered crossword toolkit for working with .puz files
 
-A rust workspace for interacting with `.puz` crossword puzzle files.
+A parsing library and CLI for the binary `.puz` format used by AcrossLite and
+most crossword apps.
 
-## Structure
+## Contents
 
-- **[`parse/`](parse/)** - core parsing library (`puz-parse` crate)
-- **[`cli/`](cli/)** - cli tool for processing files (`puz` crate)
+- [Workspace layout](#workspace-layout)
+- [Features](#features)
+- [Getting started](#getting-started)
+- [Usage](#usage)
+- [File format](#file-format)
+- [Contributing](#contributing)
+- [Releasing](#releasing)
+- [License](#license)
 
-## Quick Start
+## Workspace layout
 
-For detailed installation and usage instructions, see the individual package READMEs:
+The repository is a Cargo workspace with two crates:
 
-- **library**: See [parse/README.md](parse/README.md) for complete API documentation and examples
-- **cli**: See [cli/README.md](cli/README.md) for command-line interface options
+- [`parse/`](parse/) is the parsing library, published as
+  [`puz-parse`](https://crates.io/crates/puz-parse).
+- [`cli/`](cli/) is a command-line tool built on top of it, published as
+  [`puz`](https://crates.io/crates/puz).
+
+The `cli` crate depends on `parse`.
 
 ## Features
 
-- Complete `.puz` file format parsing
-- Support for rebus squares, circles, and other extensions
-- JSON serialization support
-- Memory-safe, zero-copy parsing where possible
-- Comprehensive error handling with warnings
+- Parses the full `.puz` binary format: metadata, grids, and clues.
+- Handles extensions like rebus squares and circled cells.
+- Validates checksums while parsing and surfaces problems as warnings.
+- Optional JSON serialization behind the `json` feature.
+- Pure, memory-safe Rust with zero-copy parsing where it's practical.
 
-## File Format
+## Getting started
 
-The library parses the binary `.puz` format used by crossword applications like AcrossLite. See `PUZ.md` for complete format documentation.
+Clone the repo:
+
+```sh
+git clone https://github.com/mwln/puz.rs.git
+cd puz.rs
+```
+
+The toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml), so
+`rustup` picks the right version automatically the first time you run a `cargo`
+command here. That keeps local builds in step with CI.
+
+Build and test the whole workspace:
+
+```sh
+cargo build
+cargo test
+```
+
+If you plan to contribute, see [CONTRIBUTING.md](CONTRIBUTING.md) for the
+checks CI runs and how to submit changes.
+
+## Usage
+
+### Library
+
+Add `puz-parse` to your `Cargo.toml`, then parse a file:
+
+```rust
+use puz_parse::parse_file;
+
+fn main() -> Result<(), puz_parse::PuzError> {
+    let puzzle = parse_file("puzzle.puz")?;
+    println!("{} by {}", puzzle.info.title, puzzle.info.author);
+    Ok(())
+}
+```
+
+Enable the `json` feature for serde support. See
+[parse/README.md](parse/README.md) for the full API, error handling, and more
+examples.
+
+### CLI
+
+The `puz` command reads one or more `.puz` files and prints their contents as
+JSON:
+
+```sh
+puz puzzle.puz --pretty
+```
+
+See [cli/README.md](cli/README.md) for the available flags and output format.
+
+## File format
+
+`.puz` is a binary format. [`PUZ.md`](PUZ.md) documents the layout the parser
+implements, from the header and checksums through the grid and extension
+sections.
+
+## Contributing
+
+Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers how to set
+up, the checks to run before opening a pull request, and the review process.
+
+## Releasing
+
+Releases are tag-driven and handled in CI. The process is documented in
+[RELEASING.md](RELEASING.md).
+
+## License
+
+Licensed under the [MIT License](LICENSE).

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,40 +1,91 @@
 # puz
 
-CLI tool for processing `.puz` crossword puzzle files and outputting structured JSON.
+A command-line tool for reading `.puz` crossword files and printing their
+contents as JSON. It's built on the
+[`puz-parse`](https://crates.io/crates/puz-parse) library.
+
+## Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Options](#options)
+- [Output format](#output-format)
+- [License](#license)
 
 ## Installation
 
-* unable to be installed right now - as name squatting @ https://crates.io/crates/puz
+```sh
+cargo install puz
+```
+
+Or build from source:
+
+```sh
+git clone https://github.com/mwln/puz.rs.git
+cd puz.rs
+cargo install --path cli
+```
+
+Prebuilt binaries for common platforms are also attached to each
+[release](https://github.com/mwln/puz.rs/releases).
 
 ## Usage
 
-```bash
-# Parse a single file to JSON
+Parse a file and print JSON to stdout:
+
+```sh
 puz puzzle.puz
+```
 
-# Parse with pretty formatting
+Pretty-print the output:
+
+```sh
 puz puzzle.puz --pretty
+```
 
-# Parse single file without array wrapper
-puz puzzle.puz --single --pretty
+Parse several files at once (they're returned as a JSON array):
 
-# Parse multiple files
+```sh
 puz puzzle1.puz puzzle2.puz --pretty
+```
 
-# Save to file
+For a single file, drop the surrounding array and print just the object:
+
+```sh
+puz puzzle.puz --single --pretty
+```
+
+Write to a file instead of stdout:
+
+```sh
 puz puzzle.puz --output output.json
 ```
 
-## Output Format
-
-The tool outputs JSON with the complete puzzle structure including:
-- Puzzle metadata (title, author, dimensions, etc.)
-- Grid data (solution and blank grids)
-- Clues (across and down)
-- Extensions (rebus, circles, given squares)
-
 ## Options
 
-- `-p, --pretty` - Pretty-print JSON output
-- `-s, --single` - Output single object instead of array for single file
-- `-o, --output <FILE>` - Write to file instead of stdout
+| Option | Description |
+| --- | --- |
+| `<FILES>...` | One or more `.puz` files to parse. Supports shell globs. |
+| `-o, --output <FILE>` | Write output to a file instead of stdout. |
+| `-p, --pretty` | Indent the JSON for readability. |
+| `-s, --single` | For a single file, output the puzzle object directly instead of wrapping it in an array. |
+
+## Output format
+
+By default the tool prints a JSON array of parsed puzzles, one entry per input
+file. With `--single` and exactly one file, it prints that puzzle object on its
+own.
+
+Each puzzle object mirrors the `puz-parse` data model:
+
+- `info`: metadata (title, author, copyright, notes, width, height, version,
+  scrambled flag)
+- `grid`: the blank and solution grids, each an array of row strings
+- `clues`: across and down clues, keyed by clue number
+- `extensions`: rebus, circled, and given squares, when the puzzle has them
+
+See the [`puz-parse` README](../parse/README.md) for what each field contains.
+
+## License
+
+Licensed under the [MIT License](../LICENSE).

--- a/parse/README.md
+++ b/parse/README.md
@@ -1,117 +1,158 @@
-# puz
+# puz-parse
 
-A Rust library for parsing `.puz` crossword puzzle files.
+A Rust library for parsing the binary `.puz` crossword format used by
+AcrossLite and most crossword apps. It reads metadata, the solution and blank
+grids, clues, and extensions like rebus and circled squares.
 
-This library provides functionality to parse the binary `.puz` file format used by crossword puzzle applications like AcrossLite. It extracts puzzle metadata, grids, clues, and advanced features like rebus squares and circled squares.
+## Contents
 
-## Features
-
-- **Complete .puz parsing** - Extracts all puzzle data including metadata, grids, and clues
-- **Rebus support** - Handles puzzles with multi-character cell entries
-- **Circled squares** - Supports puzzles with circled cells
-- **Checksum validation** - Verifies file integrity during parsing
-- **Rich metadata** - Extracts title, author, copyright, notes, and more
-- **Pure Rust** - Memory-safe with zero-copy optimizations where possible
-- **JSON ready** - Optional serde support for serialization
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Parsing API](#parsing-api)
+- [Data model](#data-model)
+- [Warnings and errors](#warnings-and-errors)
+- [Feature flags](#feature-flags)
+- [Examples](#examples)
+- [License](#license)
 
 ## Installation
 
-Add this to your `Cargo.toml`:
+```toml
+[dependencies]
+puz-parse = "0.1"
+```
+
+To derive serde `Serialize`/`Deserialize` on the puzzle types, enable the
+`json` feature:
 
 ```toml
 [dependencies]
-puz-parse = "0.1.0"
-
-# For JSON serialization support:
-puz-parse = { version = "0.1.0", features = ["json"] }
+puz-parse = { version = "0.1", features = ["json"] }
 ```
 
-## Quick Start
+## Quick start
 
 ```rust
 use puz_parse::parse_file;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Parse a .puz file
+fn main() -> Result<(), puz_parse::PuzError> {
     let puzzle = parse_file("puzzle.puz")?;
-    
-    // Access puzzle information
-    println!("Title: {}", puzzle.info.title);
-    println!("Author: {}", puzzle.info.author);
-    println!("Size: {}x{}", puzzle.info.width, puzzle.info.height);
-    
-    // Access clues
-    for (num, clue) in &puzzle.clues.across {
-        println!("{} Across: {}", num, clue);
+
+    println!("{} by {}", puzzle.info.title, puzzle.info.author);
+    println!("{}x{}", puzzle.info.width, puzzle.info.height);
+
+    for (number, clue) in &puzzle.clues.across {
+        println!("{number} across: {clue}");
     }
 
     Ok(())
 }
 ```
 
-## Advanced Usage
+## Parsing API
 
-For more control over parsing and error handling:
+There are three entry points, depending on what you're parsing and how much you
+care about warnings:
+
+- `parse_file(path)` opens a file and returns a `Puzzle`. This is the
+  convenience path and discards any non-fatal warnings.
+- `parse(reader)` parses from anything implementing `Read` and returns a
+  `ParseResult<Puzzle>`, which carries both the `Puzzle` and any warnings
+  collected during parsing.
+- `parse_bytes(&[u8])` parses puzzle data already in memory and returns a
+  `Puzzle`.
+
+Reach for `parse` when you want to see warnings (for example, a recovered
+encoding issue or a skipped extension); use `parse_file` or `parse_bytes` when
+you just want the puzzle.
 
 ```rust
-use std::fs::File;
 use puz_parse::parse;
+use std::fs::File;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let file = File::open("puzzle.puz")?;
+fn main() -> Result<(), puz_parse::PuzError> {
+    let file = File::open("puzzle.puz").expect("open puzzle.puz");
     let result = parse(file)?;
     let puzzle = result.result;
-    
-    // Handle any warnings that occurred during parsing
+
     for warning in &result.warnings {
-        eprintln!("Warning: {}", warning);
+        eprintln!("warning: {warning}");
     }
+
+    println!("parsed {}", puzzle.info.title);
 
     Ok(())
 }
 ```
 
-## Data Structure
+## Data model
 
-The parsed puzzle contains:
+`parse_file` (and the others) give you a `Puzzle`:
 
-- **`info`** - Metadata (title, author, dimensions, etc.)
-- **`grid`** - Solution and blank grids  
-- **`clues`** - Across and down clues by number
-- **`extensions`** - Advanced features (rebus, circles, given squares)
+```text
+Puzzle
+├── info: PuzzleInfo    title, author, copyright, notes, width, height,
+│                       version, is_scrambled
+├── grid: Grid          blank + solution, each a Vec<String> of rows
+├── clues: Clues        across + down, each a HashMap<u16, String> keyed by
+│                       clue number
+└── extensions: Extensions   rebus, circles, given (all optional)
+```
+
+Grid rows are strings of single-character cells:
+
+- `.` is a black/blocked square.
+- `-` is an empty square (in the blank grid).
+- Any letter or number is cell content.
+
+`extensions` is where the less common features live, and each is `Option`:
+
+- `rebus` holds a `Rebus` with a `grid: Vec<Vec<u8>>` marking rebus cells
+  (`0` means none) and a `table: HashMap<u8, String>` mapping each key to its
+  multi-character value.
+- `circles` is a `Vec<Vec<bool>>` marking circled cells, if the puzzle has any.
+- `given` is a `Vec<Vec<bool>>` marking cells that were pre-filled for the
+  solver, if any.
+
+## Warnings and errors
+
+Parsing distinguishes between problems it can recover from and problems it
+can't.
+
+Recoverable problems come back as `PuzWarning` values in
+`ParseResult::warnings` (only visible through `parse`). They cover cases like a
+skipped extension section, a recovered text-encoding issue, partial data
+recovery, or a scrambled puzzle.
+
+Fatal problems return `Err(PuzError)`. Variants describe what went wrong,
+including an invalid magic header, a checksum mismatch, bad dimensions, a
+section size mismatch, and I/O errors, so you can match on the specific case:
+
+```rust
+use puz_parse::{parse_file, PuzError};
+
+fn main() {
+    match parse_file("puzzle.puz") {
+        Ok(puzzle) => println!("parsed: {}", puzzle.info.title),
+        Err(PuzError::InvalidMagic { .. }) => eprintln!("not a .puz file"),
+        Err(e) => eprintln!("parse error: {e}"),
+    }
+}
+```
+
+## Feature flags
+
+- `json` (off by default) derives serde `Serialize`/`Deserialize` on `Puzzle`
+  and its component types, so a parsed puzzle can be serialized directly.
 
 ## Examples
 
-See the [examples](examples/) directory for more detailed usage examples.
+The [`examples/`](examples/) directory has runnable programs. Run one with:
 
-## File Format Support
-
-This library supports the complete `.puz` file format specification, including:
-
-- **Standard puzzles** - Basic crossword grids with clues
-- **Rebus squares** - Cells containing multiple characters  
-- **Circled squares** - Visual indicators for themed entries
-- **Puzzle extensions** - GRBS, RTBL, and GEXT sections
-- **Checksum validation** - File integrity verification
-- **Scrambled puzzles** - Puzzles with encoded solutions (read-only)
-
-## Error Handling
-
-The library provides detailed error information:
-
-```rust
-use puz_parse::parse_file;
-
-match parse_file("puzzle.puz") {
-    Ok(puzzle) => {
-        println!("Successfully parsed: {}", puzzle.info.title);
-    }
-    Err(e) => {
-        eprintln!("Parse error: {}", e);
-    }
-}
+```sh
+cargo run --example read-with-file
 ```
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+Licensed under the [MIT License](../LICENSE).


### PR DESCRIPTION
## What

Reworks the root and per-crate READMEs into a consistent structure with a table of contents and clear sections.

### Root `README.md`
- Descriptive title + subtitle
- Workspace layout, features
- Getting started (toolchain pinning via rust-toolchain.toml, build/test)
- Usage split into Library and CLI examples
- Links to file format, contributing, releasing, and license

### `parse/README.md`
- Fixes the title (was `# puz`, now `puz-parse`)
- Documents the three parse entry points and when to use each
- Puzzle data model + grid encoding, warnings vs errors, the json feature

### `cli/README.md`
- Real install instructions (removed the stale name-squat note)
- Options table from the actual arg definitions
- JSON output shape including `--single`

## Verification
All Rust code blocks were extracted and checked: they compile against `puz-parse` and pass `rustfmt --check` and `clippy -D warnings -D clippy::all`. This caught and fixed a dangling `?`, an import-order issue, an unused variable, and replaced an ugly `Box<dyn Error>` return with `PuzError`.

Note: the `CONTRIBUTING.md` link is intentionally ahead of that file, which lands next.