### PR TITLE
fix: correct crate metadata, CLI version, and dependency placement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,10 @@ members = ["parse", "cli"]
 resolver = "2"
 
 [workspace.dependencies]
-byteorder = "1.4.3"
+# Only genuinely shared dependencies live here. serde is used by both the
+# library (optional, behind the `json` feature) and the CLI. Single-consumer
+# dependencies are declared directly in the crate that uses them.
 serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.128"
-clap = { version = "4.0", features = ["derive"] }
-anyhow = "1.0.75"
 
 [profile.release]
 lto = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.1.3"
 edition = "2021"
 description = "Command line application for processing and interacting with .puz crossword puzzle files"
 license = "MIT"
+readme = "README.md"
 homepage = "https://github.com/mwln/puz.rs/tree/main/cli"
 repository = "https://github.com/mwln/puz.rs"
+documentation = "https://github.com/mwln/puz.rs/blob/main/cli/README.md"
+keywords = ["crossword", "puz", "puzzle", "cli", "json"]
+categories = ["command-line-utilities", "games"]
 rust-version = "1.78.0"
 
 [[bin]]
@@ -14,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 puz-parse = { version = "0.1.3", path = "../parse", features = ["json"] }
-clap = { workspace = true }
+clap = { version = "4.0", features = ["derive", "cargo"] }
 serde = { workspace = true }
-serde_json = { workspace = true }
-anyhow = { workspace = true }
+serde_json = "1.0.128"
+anyhow = "1.0.75"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use clap::{Arg, Command};
+use clap::{crate_version, Arg, Command};
 use puz_parse::parse;
 use std::fs::File;
 use std::io::{self, Write};
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
         .about("parse .puz crossword puzzle files")
         .long_about("parse .puz crossword puzzle files into structured data\n\nsupports all puzzle features including rebus squares, circled cells,\nand metadata extraction")
         .after_help("examples:\n    puz puzzle.puz                  # parse and output to stdout\n    puz *.puz --pretty              # parse multiple files with formatting\n    puz daily.puz -o output.json    # save output to file\n    puz puzzle.puz --single         # output single object for one file")
-        .version("0.1.0")
+        .version(crate_version!())
         .arg(
             Arg::new("files")
                 .help("puzzle files to process")

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -2,7 +2,7 @@
 name = "puz-parse"
 version = "0.1.3"
 edition = "2021"
-authors = ["mwln <your-email@example.com>"]
+authors = ["mwln"]
 license = "MIT"
 description = "A Rust library for parsing .puz crossword puzzle files"
 readme = "README.md"
@@ -22,7 +22,7 @@ rust-version = "1.78.0"
 name = "puz_parse"
 
 [dependencies]
-byteorder = { workspace = true }
+byteorder = "1.4.3"
 
 [features]
 default = []


### PR DESCRIPTION
Fixes three issues found in a repo audit, plus a small dependency-placement cleanup.

## Bugs fixed

- **CLI reported the wrong version.** `cli/src/main.rs` hardcoded `.version("0.1.0")` while the crate is `0.1.3`, so `puz --version` was wrong. Now uses clap's `crate_version!` (derived from `CARGO_PKG_VERSION`), which required enabling clap's `cargo` feature. Verified: `puz --version` now prints `puz 0.1.3`.
- **Placeholder author email published.** `puz-parse` had `authors = ["mwln <your-email@example.com>"]` live on crates.io. Changed to `authors = ["mwln"]` (name only).
- **CLI crate had no crates.io metadata.** Added `readme`, `documentation`, `keywords`, and `categories` (`command-line-utilities`, `games`) to `puz`, so its crates.io page matches `puz-parse`.

## Dependency placement cleanup

The workspace put every dependency in `[workspace.dependencies]`, including single-consumer ones. Reorganized so only genuinely shared deps live there:

- **Workspace:** `serde` only (used by both the library, optionally, and the CLI).
- **`parse`:** `byteorder` declared directly.
- **`cli`:** `clap`, `serde_json`, `anyhow` declared directly.

`Cargo.lock` is unchanged (resolved versions identical; declarations only relocated).

## Verification

- `puz --version` → `puz 0.1.3`
- `cargo clippy --all --all-targets -- -D warnings -D clippy::all` (+ both puz-parse feature variants) clean
- `cargo fmt --all -- --check` clean
- `cargo test --all` → 64 + 6 doctests pass