### PR TITLE
feat: add workspace metadata inheritance and shared lint policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,25 @@
 members = ["parse", "cli"]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.3"
+authors = ["mwln"]
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/mwln/puz.rs"
+rust-version = "1.78.0"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+missing_debug_implementations = "warn"
+unreachable_pub = "warn"
+
+[workspace.lints.clippy]
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+
+# Only shared dependencies; single-consumer deps live in their own crate.
 [workspace.dependencies]
-# Only genuinely shared dependencies live here. serde is used by both the
-# library (optional, behind the `json` feature) and the CLI. Single-consumer
-# dependencies are declared directly in the crate that uses them.
 serde = { version = "1.0.210", features = ["derive"] }
 
 [profile.release]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "puz"
-version = "0.1.3"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Command line application for processing and interacting with .puz crossword puzzle files"
-license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/mwln/puz.rs/tree/main/cli"
-repository = "https://github.com/mwln/puz.rs"
 documentation = "https://github.com/mwln/puz.rs/blob/main/cli/README.md"
 keywords = ["crossword", "puz", "puzzle", "cli", "json"]
 categories = ["command-line-utilities", "games"]
-rust-version = "1.78.0"
 
 [[bin]]
 name = "puz"
 path = "src/main.rs"
+
+[lints]
+workspace = true
 
 [dependencies]
 puz-parse = { version = "0.1.3", path = "../parse", features = ["json"] }

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "puz-parse"
-version = "0.1.3"
-edition = "2021"
-authors = ["mwln"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "A Rust library for parsing .puz crossword puzzle files"
 readme = "README.md"
 homepage = "https://github.com/mwln/puz.rs"
-repository = "https://github.com/mwln/puz.rs"
 documentation = "https://docs.rs/puz-parse"
 keywords = ["crossword", "parser", "puz", "puzzle", "binary-format"]
 categories = ["parser-implementations", "encoding", "games"]
@@ -16,10 +17,12 @@ exclude = [
     "target/",
     ".git/",
 ]
-rust-version = "1.78.0"
 
 [lib]
 name = "puz_parse"
+
+[lints]
+workspace = true
 
 [dependencies]
 byteorder = "1.4.3"

--- a/parse/src/parser/header.rs
+++ b/parse/src/parser/header.rs
@@ -4,13 +4,13 @@ use std::io::{BufReader, Read};
 
 #[derive(Debug)]
 pub(crate) struct Header {
-    pub width: u8,
-    pub height: u8,
-    pub num_clues: u16,
-    pub version: String,
+    pub(crate) width: u8,
+    pub(crate) height: u8,
+    pub(crate) num_clues: u16,
+    pub(crate) version: String,
     #[allow(dead_code)]
-    pub bitmask: u16,
-    pub is_scrambled: bool,
+    pub(crate) bitmask: u16,
+    pub(crate) is_scrambled: bool,
 }
 
 pub(crate) fn parse_header<R: Read>(reader: &mut BufReader<R>) -> Result<Header, PuzError> {

--- a/parse/src/parser/strings.rs
+++ b/parse/src/parser/strings.rs
@@ -4,11 +4,11 @@ use std::io::{BufReader, Read};
 
 #[derive(Debug)]
 pub(crate) struct StringData {
-    pub title: String,
-    pub author: String,
-    pub copyright: String,
-    pub notes: String,
-    pub clues: Vec<String>,
+    pub(crate) title: String,
+    pub(crate) author: String,
+    pub(crate) copyright: String,
+    pub(crate) notes: String,
+    pub(crate) clues: Vec<String>,
 }
 
 pub(crate) fn parse_strings<R: Read>(


### PR DESCRIPTION
## What

Two workspace-level improvements plus a small visibility fix they surfaced.

### `[workspace.package]` inheritance
Move shared package metadata (version, authors, edition, license, repository, rust-version) to the workspace root; both crates inherit with `field.workspace = true`. Removes the duplication between `parse` and `cli`. Per-crate fields (description, keywords, categories, readme, homepage) stay in each crate. As a bonus, the `cli` crate now gets `authors` metadata it previously lacked.

### `[workspace.lints]` shared policy
Both crates opt in via `[lints] workspace = true`:
- `unsafe_code = "forbid"` (the parser uses no unsafe)
- `missing_debug_implementations = "warn"`
- `unreachable_pub = "warn"`
- clippy `correctness` (deny) + `suspicious` (warn)

This set was chosen to be **already clean** on both stable and the 1.78.0 MSRV, so it adds enforcement without a wall of new warnings. (missing_docs and clippy::pedantic were deliberately deferred to their own follow-up PRs, since they'd require ~34 doc + ~30 code changes.)

### Visibility fix
`unreachable_pub` flagged 11 `pub` fields on the internal `Header` and `StringData` structs (only warned on 1.78.0 due to lint evolution). Those fields are never reachable outside the crate, so they're now `pub(crate)`.

## Verification

- Clean on **1.78.0 (MSRV)**: `cargo +1.78.0 check --all --all-features` = 0 warnings
- Clean on **stable**: `cargo clippy --all --all-targets -- -D warnings -D clippy::all`
- `cargo fmt --all -- --check` clean
- `cargo test --all` = 64 + 6 doctests pass
- Both crates still resolve to 0.1.3 (inheritance works); `Cargo.lock` unchanged