### PR TITLE
feat: add justfile with a check recipe mirroring CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,31 @@
+# Show available recipes.
+default:
+    @just --list
+
+# Format the whole workspace.
+fmt:
+    cargo fmt --all
+
+# Check formatting without modifying files (as CI does).
+fmt-check:
+    cargo fmt --all -- --check
+
+# Run clippy across the workspace and both puz-parse feature variants.
+lint:
+    cargo clippy --all --all-targets -- -D warnings -D clippy::all
+    cargo clippy -p puz-parse --no-default-features -- -D warnings -D clippy::all
+    cargo clippy -p puz-parse --features json -- -D warnings -D clippy::all
+
+# Run the tests, including both puz-parse feature variants and the CLI smoke test.
+test:
+    cargo test --all
+    cargo test -p puz-parse --no-default-features
+    cargo test -p puz-parse --features json
+    cargo run --bin puz -- --help
+
+# Build the docs with warnings denied (as CI does).
+docs:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all --all-features
+
+# Run everything CI checks. Run this before pushing.
+check: fmt-check lint test docs


### PR DESCRIPTION
## What

Adds a `justfile` so contributors have a single, discoverable way to run the same checks CI runs.

Recipes:
- `just fmt` / `just fmt-check` — format, or check formatting like CI
- `just lint` — clippy across the workspace + both `puz-parse` feature variants
- `just test` — tests + both feature variants + the CLI `--help` smoke test
- `just docs` — docs build with `RUSTDOCFLAGS=-D warnings`
- `just check` — runs all of the above; **run before pushing**
- `just` (default) — lists recipes

The commands mirror `.github/workflows/ci.yml` exactly.

## Verification

- `just check` runs the full sequence and exits 0 (matches CI's green state), including the CLI smoke test and warnings-denied docs build.
- Recipes verified under `just` 1.55.1.

## Notes

- CI remains the source of truth; the justfile is contributor convenience. They can drift in principle, so CONTRIBUTING.md (next) will point contributors at `just check` and note it mirrors CI.
- CONTRIBUTING will also instruct `cargo install just`.