### PR TITLE
bench: generate fixtures in-code, exclude benches from package

### DIFF
--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -12,7 +12,9 @@ homepage = "https://github.com/mwln/puz.rs"
 documentation = "https://docs.rs/puz-parse"
 keywords = ["crossword", "parser", "puz", "puzzle", "binary-format"]
 categories = ["parser-implementations", "encoding", "games"]
+autobenches = false
 exclude = [
+    "benches/",
     "examples/data/*.puz",
     "target/",
     ".git/",

--- a/parse/benches/fixtures.rs
+++ b/parse/benches/fixtures.rs
@@ -27,7 +27,11 @@ pub(crate) fn all() -> Vec<Fixture> {
     let mut out = Vec::new();
 
     // Size sweep on plain (all-open) grids.
-    for (name, n) in [("small_5x5", 5), ("standard_15x15", 15), ("large_21x21", 21)] {
+    for (name, n) in [
+        ("small_5x5", 5),
+        ("standard_15x15", 15),
+        ("large_21x21", 21),
+    ] {
         out.push(build(name, plain(n)));
     }
 
@@ -120,9 +124,7 @@ fn with_rebus(mut p: Puzzle) -> Puzzle {
 fn with_circles(mut p: Puzzle) -> Puzzle {
     let (w, h) = (p.info.width as usize, p.info.height as usize);
     // Circle the main diagonal.
-    let grid = (0..h)
-        .map(|r| (0..w).map(|c| r == c).collect())
-        .collect();
+    let grid = (0..h).map(|r| (0..w).map(|c| r == c).collect()).collect();
     p.extensions.circles = Some(grid);
     p
 }
@@ -130,9 +132,7 @@ fn with_circles(mut p: Puzzle) -> Puzzle {
 fn with_given(mut p: Puzzle) -> Puzzle {
     let (w, h) = (p.info.width as usize, p.info.height as usize);
     // Mark the first row as given.
-    let grid = (0..h)
-        .map(|r| (0..w).map(|_| r == 0).collect())
-        .collect();
+    let grid = (0..h).map(|r| (0..w).map(|_| r == 0).collect()).collect();
     p.extensions.given = Some(grid);
     p
 }

--- a/parse/benches/fixtures.rs
+++ b/parse/benches/fixtures.rs
@@ -24,23 +24,23 @@ pub(crate) struct Fixture {
 /// Build the standard set of benchmark fixtures: a size sweep plus
 /// feature-specific variants (rebus, circles, given).
 pub(crate) fn all() -> Vec<Fixture> {
-    let mut out = Vec::new();
+    let mut fixtures = Vec::new();
 
     // Size sweep on plain (all-open) grids.
-    for (name, n) in [
+    for (name, size) in [
         ("small_5x5", 5),
         ("standard_15x15", 15),
         ("large_21x21", 21),
     ] {
-        out.push(build(name, plain(n)));
+        fixtures.push(build(name, plain(size)));
     }
 
     // Feature variants on a standard-sized grid.
-    out.push(build("rebus_15x15", with_rebus(plain(15))));
-    out.push(build("circles_15x15", with_circles(plain(15))));
-    out.push(build("given_15x15", with_given(plain(15))));
+    fixtures.push(build("rebus_15x15", with_rebus(plain(15))));
+    fixtures.push(build("circles_15x15", with_circles(plain(15))));
+    fixtures.push(build("given_15x15", with_given(plain(15))));
 
-    out
+    fixtures
 }
 
 /// Serialize a puzzle into a `Fixture`, panicking if the writer rejects it
@@ -55,35 +55,18 @@ fn build(name: &str, puzzle: Puzzle) -> Fixture {
     }
 }
 
-/// Build a plain `n`x`n` puzzle with no black squares and every implied clue
-/// filled in. An open grid's numbering is simple: each row starts one across
-/// word and each column starts one down word, numbered in reading order.
-fn plain(n: usize) -> Puzzle {
-    let solution: Vec<String> = (0..n)
-        .map(|r| (0..n).map(|c| letter(r, c)).collect())
-        .collect();
-    let blank: Vec<String> = (0..n).map(|_| "-".repeat(n)).collect();
-
-    // Numbering: walk reading order; a cell starts across if col == 0, starts
-    // down if row == 0 (true for an all-open grid).
-    let mut across = HashMap::new();
-    let mut down = HashMap::new();
-    let mut number = 1u16;
-    for r in 0..n {
-        for c in 0..n {
-            let starts_across = c == 0;
-            let starts_down = r == 0;
-            if starts_across || starts_down {
-                if starts_across {
-                    across.insert(number, format!("across {number}"));
-                }
-                if starts_down {
-                    down.insert(number, format!("down {number}"));
-                }
-                number += 1;
-            }
-        }
+/// Build a plain `size`x`size` puzzle with no black squares and every implied
+/// clue filled in. An open grid's numbering is simple: each row starts one
+/// across word and each column starts one down word, numbered in reading order.
+fn plain(size: usize) -> Puzzle {
+    let mut solution = Vec::with_capacity(size);
+    for row in 0..size {
+        let cells: String = (0..size).map(|col| letter(row, col)).collect();
+        solution.push(cells);
     }
+    let blank: Vec<String> = (0..size).map(|_| "-".repeat(size)).collect();
+
+    let clues = clues_for_open_grid(size);
 
     Puzzle {
         info: PuzzleInfo {
@@ -91,13 +74,13 @@ fn plain(n: usize) -> Puzzle {
             author: "Generated".into(),
             copyright: "(c) puz.rs".into(),
             notes: String::new(),
-            width: n as u8,
-            height: n as u8,
+            width: size as u8,
+            height: size as u8,
             version: "1.3".into(),
             is_scrambled: false,
         },
         grid: Grid { solution, blank },
-        clues: Clues { across, down },
+        clues,
         extensions: Extensions {
             rebus: None,
             circles: None,
@@ -106,33 +89,92 @@ fn plain(n: usize) -> Puzzle {
     }
 }
 
-/// Deterministic letter for cell `(r, c)`.
-fn letter(r: usize, c: usize) -> char {
-    (b'A' + ((r * 7 + c * 3) % 26) as u8) as char
+/// Generate the exact set of clues an all-open `size`x`size` grid requires.
+///
+/// Walking in reading order, a cell starts an across word when it is in the
+/// first column, and a down word when it is in the first row. Each numbered
+/// cell advances the clue number once.
+fn clues_for_open_grid(size: usize) -> Clues {
+    let mut across = HashMap::new();
+    let mut down = HashMap::new();
+    let mut number = 1u16;
+
+    for row in 0..size {
+        for col in 0..size {
+            let starts_across = col == 0;
+            let starts_down = row == 0;
+            if !(starts_across || starts_down) {
+                continue;
+            }
+            if starts_across {
+                across.insert(number, format!("across {number}"));
+            }
+            if starts_down {
+                down.insert(number, format!("down {number}"));
+            }
+            number += 1;
+        }
+    }
+
+    Clues { across, down }
 }
 
-fn with_rebus(mut p: Puzzle) -> Puzzle {
-    let (w, h) = (p.info.width as usize, p.info.height as usize);
-    let mut grid = vec![vec![0u8; w]; h];
-    grid[0][0] = 1; // one rebus cell
+/// A reproducible letter for the cell at `(row, col)`.
+///
+/// Benchmarks need deterministic, non-uniform grid content: fixed so runs are
+/// comparable, but varied so a grid of identical bytes doesn't hand the parser
+/// or checksum an unrealistic fast path. The exact scramble is unimportant — we
+/// just spread letters across the alphabet.
+fn letter(row: usize, col: usize) -> char {
+    const ALPHABET: &[u8; 26] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    ALPHABET[(row * 7 + col * 3) % ALPHABET.len()] as char
+}
+
+/// Add a single rebus cell (top-left) with a one-entry solution table.
+fn with_rebus(mut puzzle: Puzzle) -> Puzzle {
+    let width = puzzle.info.width as usize;
+    let height = puzzle.info.height as usize;
+
+    let mut rebus_grid = vec![vec![0u8; width]; height];
+    rebus_grid[0][0] = 1; // rebus key 1 at the top-left cell
+
     let mut table = HashMap::new();
     table.insert(1u8, "HEART".to_string());
-    p.extensions.rebus = Some(Rebus { grid, table });
-    p
+
+    puzzle.extensions.rebus = Some(Rebus {
+        grid: rebus_grid,
+        table,
+    });
+    puzzle
 }
 
-fn with_circles(mut p: Puzzle) -> Puzzle {
-    let (w, h) = (p.info.width as usize, p.info.height as usize);
-    // Circle the main diagonal.
-    let grid = (0..h).map(|r| (0..w).map(|c| r == c).collect()).collect();
-    p.extensions.circles = Some(grid);
-    p
+/// Circle the cells along the main diagonal.
+fn with_circles(mut puzzle: Puzzle) -> Puzzle {
+    let width = puzzle.info.width as usize;
+    let height = puzzle.info.height as usize;
+
+    let mut circled = vec![vec![false; width]; height];
+    for (row, cells) in circled.iter_mut().enumerate() {
+        // A cell is on the main diagonal when its column equals its row.
+        if row < width {
+            cells[row] = true;
+        }
+    }
+
+    puzzle.extensions.circles = Some(circled);
+    puzzle
 }
 
-fn with_given(mut p: Puzzle) -> Puzzle {
-    let (w, h) = (p.info.width as usize, p.info.height as usize);
-    // Mark the first row as given.
-    let grid = (0..h).map(|r| (0..w).map(|_| r == 0).collect()).collect();
-    p.extensions.given = Some(grid);
-    p
+/// Mark the first row of cells as "given" (pre-filled for the solver).
+fn with_given(mut puzzle: Puzzle) -> Puzzle {
+    let width = puzzle.info.width as usize;
+    let height = puzzle.info.height as usize;
+
+    let mut given = vec![vec![false; width]; height];
+    if let Some(first_row) = given.first_mut() {
+        first_row.fill(true);
+    }
+
+    puzzle.extensions.given = Some(given);
+    puzzle
 }

--- a/parse/benches/fixtures.rs
+++ b/parse/benches/fixtures.rs
@@ -1,0 +1,138 @@
+//! In-code fixture generation for benchmarks.
+//!
+//! Rather than bundling `.puz` files, we build `Puzzle` values programmatically
+//! and use the library's own writer (`to_bytes`) to produce the byte buffers we
+//! parse. This keeps benchmarks focused on core-library performance (no file
+//! I/O, no bundled fixtures) and lets us vary size and features freely.
+//!
+//! Note: benchmarks only *time* code, they don't assert correctness, so using
+//! the writer to generate parser inputs is fine here — a shared bug would show
+//! up in the correctness test suite, not silently pass a benchmark.
+
+use puz_parse::{Clues, Extensions, Grid, Puzzle, PuzzleInfo, Rebus};
+use std::collections::HashMap;
+
+/// A generated puzzle plus its serialized bytes, ready for benchmarking either
+/// direction.
+#[derive(Debug)]
+pub(crate) struct Fixture {
+    pub(crate) name: String,
+    pub(crate) puzzle: Puzzle,
+    pub(crate) bytes: Vec<u8>,
+}
+
+/// Build the standard set of benchmark fixtures: a size sweep plus
+/// feature-specific variants (rebus, circles, given).
+pub(crate) fn all() -> Vec<Fixture> {
+    let mut out = Vec::new();
+
+    // Size sweep on plain (all-open) grids.
+    for (name, n) in [("small_5x5", 5), ("standard_15x15", 15), ("large_21x21", 21)] {
+        out.push(build(name, plain(n)));
+    }
+
+    // Feature variants on a standard-sized grid.
+    out.push(build("rebus_15x15", with_rebus(plain(15))));
+    out.push(build("circles_15x15", with_circles(plain(15))));
+    out.push(build("given_15x15", with_given(plain(15))));
+
+    out
+}
+
+/// Serialize a puzzle into a `Fixture`, panicking if the writer rejects it
+/// (which would indicate a bug in the generator).
+fn build(name: &str, puzzle: Puzzle) -> Fixture {
+    let bytes = puz_parse::to_bytes(&puzzle)
+        .unwrap_or_else(|e| panic!("fixture {name} failed to serialize: {e}"));
+    Fixture {
+        name: name.to_string(),
+        puzzle,
+        bytes,
+    }
+}
+
+/// Build a plain `n`x`n` puzzle with no black squares and every implied clue
+/// filled in. An open grid's numbering is simple: each row starts one across
+/// word and each column starts one down word, numbered in reading order.
+fn plain(n: usize) -> Puzzle {
+    let solution: Vec<String> = (0..n)
+        .map(|r| (0..n).map(|c| letter(r, c)).collect())
+        .collect();
+    let blank: Vec<String> = (0..n).map(|_| "-".repeat(n)).collect();
+
+    // Numbering: walk reading order; a cell starts across if col == 0, starts
+    // down if row == 0 (true for an all-open grid).
+    let mut across = HashMap::new();
+    let mut down = HashMap::new();
+    let mut number = 1u16;
+    for r in 0..n {
+        for c in 0..n {
+            let starts_across = c == 0;
+            let starts_down = r == 0;
+            if starts_across || starts_down {
+                if starts_across {
+                    across.insert(number, format!("across {number}"));
+                }
+                if starts_down {
+                    down.insert(number, format!("down {number}"));
+                }
+                number += 1;
+            }
+        }
+    }
+
+    Puzzle {
+        info: PuzzleInfo {
+            title: "Benchmark".into(),
+            author: "Generated".into(),
+            copyright: "(c) puz.rs".into(),
+            notes: String::new(),
+            width: n as u8,
+            height: n as u8,
+            version: "1.3".into(),
+            is_scrambled: false,
+        },
+        grid: Grid { solution, blank },
+        clues: Clues { across, down },
+        extensions: Extensions {
+            rebus: None,
+            circles: None,
+            given: None,
+        },
+    }
+}
+
+/// Deterministic letter for cell `(r, c)`.
+fn letter(r: usize, c: usize) -> char {
+    (b'A' + ((r * 7 + c * 3) % 26) as u8) as char
+}
+
+fn with_rebus(mut p: Puzzle) -> Puzzle {
+    let (w, h) = (p.info.width as usize, p.info.height as usize);
+    let mut grid = vec![vec![0u8; w]; h];
+    grid[0][0] = 1; // one rebus cell
+    let mut table = HashMap::new();
+    table.insert(1u8, "HEART".to_string());
+    p.extensions.rebus = Some(Rebus { grid, table });
+    p
+}
+
+fn with_circles(mut p: Puzzle) -> Puzzle {
+    let (w, h) = (p.info.width as usize, p.info.height as usize);
+    // Circle the main diagonal.
+    let grid = (0..h)
+        .map(|r| (0..w).map(|c| r == c).collect())
+        .collect();
+    p.extensions.circles = Some(grid);
+    p
+}
+
+fn with_given(mut p: Puzzle) -> Puzzle {
+    let (w, h) = (p.info.width as usize, p.info.height as usize);
+    // Mark the first row as given.
+    let grid = (0..h)
+        .map(|r| (0..w).map(|_| r == 0).collect())
+        .collect();
+    p.extensions.given = Some(grid);
+    p
+}

--- a/parse/benches/parse.rs
+++ b/parse/benches/parse.rs
@@ -1,4 +1,10 @@
-//! Benchmarks for the parse and write paths.
+//! Benchmarks for the core parse and write paths.
+//!
+//! Inputs are generated in-code via the library's own writer (see
+//! `fixtures.rs`) so the benchmarks measure library performance only — no file
+//! I/O and no bundled `.puz` files. A size sweep (5x5 / 15x15 / 21x21) plus
+//! feature variants (rebus, circles, given) reveal both scaling and per-feature
+//! cost.
 //!
 //! Run with `cargo bench`. Compare runs with `critcmp` by saving baselines:
 //!     cargo bench -- --save-baseline before
@@ -6,44 +12,48 @@
 //!     cargo bench -- --save-baseline after
 //!     critcmp before after
 
-use criterion::{criterion_group, criterion_main, Criterion};
+mod fixtures;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use puz_parse::{parse_bytes, to_bytes};
 use std::hint::black_box;
 
-// Fixtures embedded at compile time (they are excluded from the published
-// package, so we can't read them from disk in all contexts).
-const STANDARD: &[u8] = include_bytes!("../examples/data/standard1.puz");
-const REBUS: &[u8] = include_bytes!("../examples/data/rebus.puz");
-const CIRCLED: &[u8] = include_bytes!("../examples/data/circled.puz");
-
 fn bench_parse(c: &mut Criterion) {
+    let fixtures = fixtures::all();
     let mut group = c.benchmark_group("parse");
-    for (name, data) in [
-        ("standard", STANDARD),
-        ("rebus", REBUS),
-        ("circled", CIRCLED),
-    ] {
-        group.bench_function(name, |b| b.iter(|| parse_bytes(black_box(data)).unwrap()));
+    for f in &fixtures {
+        group.throughput(Throughput::Bytes(f.bytes.len() as u64));
+        group.bench_function(&f.name, |b| {
+            b.iter(|| parse_bytes(black_box(&f.bytes)).unwrap())
+        });
     }
     group.finish();
 }
 
 fn bench_write(c: &mut Criterion) {
-    // Parse once up front; benchmark only the write path.
-    let puzzle = parse_bytes(STANDARD).unwrap();
-    c.bench_function("write/standard", |b| {
-        b.iter(|| to_bytes(black_box(&puzzle)).unwrap())
-    });
+    let fixtures = fixtures::all();
+    let mut group = c.benchmark_group("write");
+    for f in &fixtures {
+        group.throughput(Throughput::Bytes(f.bytes.len() as u64));
+        group.bench_function(&f.name, |b| {
+            b.iter(|| to_bytes(black_box(&f.puzzle)).unwrap())
+        });
+    }
+    group.finish();
 }
 
 fn bench_round_trip(c: &mut Criterion) {
-    let puzzle = parse_bytes(STANDARD).unwrap();
-    c.bench_function("round_trip/standard", |b| {
-        b.iter(|| {
-            let bytes = to_bytes(black_box(&puzzle)).unwrap();
-            parse_bytes(black_box(&bytes)).unwrap()
-        })
-    });
+    let fixtures = fixtures::all();
+    let mut group = c.benchmark_group("round_trip");
+    for f in &fixtures {
+        group.bench_function(&f.name, |b| {
+            b.iter(|| {
+                let bytes = to_bytes(black_box(&f.puzzle)).unwrap();
+                parse_bytes(black_box(&bytes)).unwrap()
+            })
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(benches, bench_parse, bench_write, bench_round_trip);


### PR DESCRIPTION
## Summary

Makes the benchmarks self-contained and keeps bench tooling out of the public package.

- **Generate fixtures via the writer** instead of `include_bytes!`ing bundled `.puz` files. `benches/fixtures.rs` builds `Puzzle` values (size sweep 5×5 / 15×15 / 21×21, plus rebus/circles/given variants) and serializes them with `to_bytes` to produce parser inputs.
- Benchmarks now measure **core-library performance only** — no file I/O, no bundled fixtures — and the size sweep reveals scaling plus per-feature cost.
- `autobenches = false` so only the declared `parse` bench is a target (`fixtures.rs` is a module of it).
- **Exclude `benches/` from the published package** so bench code never ships to crates.io consumers. (criterion was already a dev-only dependency.)

This also removes the benchmark's dependency on the example `.puz` files that #28 deletes, unblocking that cleanup.

## Verification

- `cargo bench` runs; fixtures generate and serialize without error.
- 119 unit + 10 doctests pass; clippy clean (incl. benches); MSRV 1.78 check passes with benches.
- `cargo package --list` confirms `benches/` is no longer in the published package.

## Test Plan

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets`
- [ ] `cargo bench -p puz-parse`