### PR TITLE
fix: measure grid rows by cell count, not byte length

### DIFF
--- a/parse/src/grid.rs
+++ b/parse/src/grid.rs
@@ -74,7 +74,11 @@ pub(crate) fn count_clues(grid: &[String]) -> (usize, usize) {
     let mut down_count = 0;
 
     let height = grid.len();
-    let width = if height > 0 { grid[0].len() } else { 0 };
+    let width = if height > 0 {
+        grid[0].chars().count()
+    } else {
+        0
+    };
 
     for row in 0..height {
         for col in 0..width {
@@ -108,7 +112,11 @@ pub(crate) fn order_clues(
 ) -> Result<Vec<String>, crate::error::PuzError> {
     let mut ordered = Vec::new();
     let height = blank_grid.len();
-    let width = if height > 0 { blank_grid[0].len() } else { 0 };
+    let width = if height > 0 {
+        blank_grid[0].chars().count()
+    } else {
+        0
+    };
     let mut number = 1u16;
 
     for row in 0..height {

--- a/parse/src/parser/grids.rs
+++ b/parse/src/parser/grids.rs
@@ -65,14 +65,15 @@ fn validate_grid_consistency(
     }
 
     for (i, (sol_row, blank_row)) in solution.iter().zip(blank.iter()).enumerate() {
-        if sol_row.len() != width as usize || blank_row.len() != width as usize {
+        // Each grid cell is one character (a byte may decode to a multi-byte
+        // char, e.g. a high byte used as a rebus marker), so compare cell
+        // counts via `chars().count()`, not byte length.
+        let sol_cells = sol_row.chars().count();
+        let blank_cells = blank_row.chars().count();
+        if sol_cells != width as usize || blank_cells != width as usize {
             return Err(PuzError::InvalidGrid {
                 reason: format!(
-                    "Grid width mismatch at row {}: expected {}, got solution: {}, blank: {}",
-                    i,
-                    width,
-                    sol_row.len(),
-                    blank_row.len()
+                    "Grid width mismatch at row {i}: expected {width}, got solution: {sol_cells}, blank: {blank_cells}"
                 ),
             });
         }
@@ -123,6 +124,33 @@ mod tests {
         assert_eq!(grid.blank[0], "---");
         assert_eq!(grid.blank[1], ".--");
         assert_eq!(grid.blank[2], "---");
+    }
+
+    /// Test parsing a grid whose solution contains a non-ASCII cell byte.
+    ///
+    /// Some puzzles use high bytes (e.g. 0xC2) as rebus/special-cell markers.
+    /// Each cell is one byte -> one char, so a row must validate by cell count,
+    /// not UTF-8 byte length. Byte 0xC2 decodes to 'Â' (2 UTF-8 bytes), so a
+    /// byte-length check would see width 3 for a 2-cell row and wrongly reject.
+    #[test]
+    fn test_parse_grids_non_ascii_cell() {
+        let width = 2u8;
+        let height = 2u8;
+
+        // Row 0 solution: [0xC2, 'B'] = one high-byte cell + one letter.
+        let solution_data = [0xC2, b'B', b'C', b'D'];
+        let blank_data = *b"----";
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&solution_data);
+        data.extend_from_slice(&blank_data);
+
+        let mut reader = BufReader::new(Cursor::new(data));
+        let grid = parse_grids(&mut reader, width, height).unwrap();
+
+        assert_eq!(grid.solution[0].chars().count(), 2);
+        assert_eq!(grid.solution[0], "\u{00C2}B");
+        assert_eq!(grid.blank[0], "--");
     }
 
     /// Test parsing grids with all black squares

--- a/parse/src/parser/validation.rs
+++ b/parse/src/parser/validation.rs
@@ -27,7 +27,10 @@ fn validate_grid_structure(blank: &[String], solution: &[String]) -> Result<(), 
     }
 
     for (i, (blank_row, solution_row)) in blank.iter().zip(solution.iter()).enumerate() {
-        if blank_row.len() != solution_row.len() {
+        // Compare cell counts, not byte lengths: a cell byte may decode to a
+        // multi-byte char, so String::len() (bytes) can differ between grids
+        // that have the same number of cells.
+        if blank_row.chars().count() != solution_row.chars().count() {
             return Err(PuzError::InvalidGrid {
                 reason: format!("Row {i} has mismatched widths"),
             });


### PR DESCRIPTION
## Summary

Fixes valid puzzles being rejected with "Grid width mismatch" when a solution cell uses a non-ASCII byte.

Grid rows are `String`s with one character per cell, but a cell byte can decode to a multi-byte `char` — e.g. `0xC2`, used in some NYT puzzles as a rebus/special-cell marker, decodes to `Â` (two UTF-8 bytes). Row-width validation compared `String::len()` (byte length) against the declared width, so a 15-cell row containing one such cell measured as 17 bytes and was wrongly rejected.

The fix uses `chars().count()` (cell count) at every grid-row width site:
- grid consistency check (`parser/grids.rs`)
- grid structure validation (`parser/validation.rs`)
- width derivation in `count_clues` / `order_clues` (`grid.rs`)

Row *count* checks (`Vec::len` on the outer grid) were already correct and unchanged.

## Verification

- New regression test: a grid with a `0xC2` cell parses to a 2-cell row instead of failing.
- **Corpus:** all "width mismatch" parse errors are eliminated on a ~10,800-file archive.
- 120 unit + 10 doctests pass; fmt + clippy (all permutations) clean; MSRV 1.78 builds.

## Scope note

The two files this bug affected also trigger a *separate* over-strict grid-character validation (rejecting `Â` as an invalid cell char). That is a distinct bug, tracked as the next fix — this PR deliberately addresses only the byte-length root cause.

## Test Plan

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets`