### PR TITLE
refactor(parse): tidy public API and adopt thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,33 +34,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -81,9 +81,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -172,15 +172,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
@@ -334,12 +334,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -373,9 +374,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -388,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -432,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-traits"
@@ -453,9 +454,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -532,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -559,22 +560,23 @@ dependencies = [
  "byteorder",
  "criterion",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -582,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -601,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -613,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -648,12 +650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,18 +666,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -690,14 +696,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -739,13 +746,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -760,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -886,73 +913,35 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "zerocopy"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "zerocopy-derive",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "zerocopy-derive"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
+name = "zmij"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@ The `cli` crate depends on `parse`.
 
 ## Features
 
-- Parses the full `.puz` binary format: metadata, grids, and clues.
-- Handles extensions like rebus squares and circled cells.
+- Parses the full `.puz` binary format: metadata, grids, clues, and extensions
+  like rebus squares and circled cells.
+- Writes `.puz` files back out, including diagramless puzzles, so puzzles
+  round-trip.
+- Builds puzzles in code with `Puzzle::new()` and reads clue/answer pairs off
+  the grid.
 - Validates checksums while parsing and surfaces problems as warnings.
+- CLI for parsing to JSON, bulk validation, raw-structure inspection, and
+  clue/answer export.
 - Optional JSON serialization behind the `json` feature.
-- Pure, memory-safe Rust with zero-copy parsing where it's practical.
+- Pure, memory-safe Rust (`unsafe` is forbidden).
 
 ## Getting started
 
@@ -63,10 +69,10 @@ checks CI runs and how to submit changes.
 Add `puz-parse` to your `Cargo.toml`, then parse a file:
 
 ```rust
-use puz_parse::parse_file;
+use puz_parse::Puzzle;
 
 fn main() -> Result<(), puz_parse::PuzError> {
-    let puzzle = parse_file("puzzle.puz")?;
+    let puzzle = Puzzle::from_file("puzzle.puz")?;
     println!("{} by {}", puzzle.info.title, puzzle.info.author);
     Ok(())
 }
@@ -78,14 +84,17 @@ examples.
 
 ### CLI
 
-The `puz` command reads one or more `.puz` files and prints their contents as
-JSON:
+The `puz` command is a toolkit for `.puz` files. By default it parses to JSON,
+with subcommands for validation, inspection, and data export:
 
 ```sh
-puz puzzle.puz --pretty
+puz puzzle.puz --pretty        # parse to JSON
+puz validate ./puzzles         # bulk-validate a directory
+puz dump grid puzzle.puz       # show the raw grid structure
+puz export ./puzzles           # clue/answer pairs as JSON Lines
 ```
 
-See [cli/README.md](cli/README.md) for the available flags and output format.
+See [cli/README.md](cli/README.md) for the full command reference.
 
 ## File format
 

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -31,6 +31,7 @@ workspace = true
 
 [dependencies]
 byteorder = "1.4.3"
+thiserror = "2.0"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/parse/src/checksums.rs
+++ b/parse/src/checksums.rs
@@ -442,7 +442,9 @@ mod tests {
         // char © is representable in Windows-1252, so a decode+re-encode changes
         // the byte count; validation must use the raw bytes and accept the file.
         let bytes = build_puz(b"ABCD", "Test", "Author", "© Sample Corp Inc.", "");
-        crate::validate_bytes(&bytes)
+        crate::Puzzle::reader()
+            .strict(true)
+            .from_bytes(&bytes)
             .expect("valid file with a UTF-8-encoded copyright must pass validation");
     }
 
@@ -453,7 +455,9 @@ mod tests {
         // computed over the original byte 0xC2, not a UTF-8 re-encoding of the
         // decoded char (which would be 0xC3 0x82), or validation wrongly fails.
         let bytes = build_puz(&[0xC2, b'B', b'C', b'D'], "T", "A", "", "");
-        crate::validate_bytes(&bytes)
+        crate::Puzzle::reader()
+            .strict(true)
+            .from_bytes(&bytes)
             .expect("valid file with a high-byte grid cell must pass validation");
     }
 }

--- a/parse/src/error.rs
+++ b/parse/src/error.rs
@@ -1,41 +1,67 @@
-use std::{error::Error as StdError, fmt, io};
+use std::io;
+
+use thiserror::Error;
 
 /// Warnings that can occur during parsing but don't prevent puzzle creation.
 ///
 /// These indicate non-critical issues that were encountered during parsing
 /// but were handled gracefully. The parsing can continue and produce a valid
 /// puzzle, but some information might be missing or using fallback values.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum PuzWarning {
-    /// An optional extension section was skipped due to parsing issues
+    /// An optional extension section was skipped due to parsing issues.
+    #[error("Skipped extension section '{section}': {reason}")]
     SkippedExtension { section: String, reason: String },
-    /// Character encoding issues were encountered but handled
+
+    /// Character encoding issues were encountered but handled.
+    #[error("Encoding issue in {context}: {}", recovery_note(*recovered))]
     EncodingIssue { context: String, recovered: bool },
-    /// Invalid data was found but default values were used
+
+    /// Invalid data was found but default values were used.
+    #[error("Data recovery for '{field}': {issue}")]
     DataRecovery { field: String, issue: String },
-    /// Puzzle is scrambled and may not display correctly
+
+    /// Puzzle is scrambled and may not display correctly.
+    #[error(
+        "Puzzle is scrambled (version {version}). Solution may not be readable without descrambling."
+    )]
     ScrambledPuzzle { version: String },
+
     /// A stored checksum did not match the recomputed value (non-fatal in
-    /// lenient parsing; many real-world files have incorrect checksums)
+    /// lenient parsing; many real-world files have incorrect checksums).
+    #[error(
+        "Checksum mismatch in {context}: expected 0x{expected:04X}, found 0x{found:04X}. The file may be corrupted."
+    )]
     ChecksumMismatch {
         context: String,
         expected: u16,
         found: u16,
     },
+
     /// A solution cell holds a non-standard character (not a letter, digit, or
     /// black square) with no rebus entry at that position. It could be a rebus
     /// glyph the file failed to describe, or it could be corruption.
+    #[error(
+        "Solution cell ({row}, {col}) has non-standard character '{character}' (U+{:04X}) with no rebus entry at that position.",
+        *character as u32
+    )]
     UnbackedGridChar {
         character: char,
         row: usize,
         col: usize,
     },
+
     /// The file stored more clue strings than the grid has word slots. The
     /// extra strings are preserved in [`Clues::raw`](crate::Clues::raw); the
     /// numbered across/down maps use the first `slots` clues in reading order.
     /// Some puzzles include extra authored clues (for example a meta-puzzle
     /// revealer) that do not correspond to a grid slot.
+    #[error(
+        "File provided {provided} clue strings but the grid has {slots} word slots; \
+         the {} extra clue(s) are preserved in Clues::raw.",
+        provided - slots
+    )]
     ExtraClues {
         /// Number of grid word slots (mapped clues).
         slots: usize,
@@ -44,317 +70,144 @@ pub enum PuzWarning {
     },
 }
 
+fn recovery_note(recovered: bool) -> &'static str {
+    if recovered {
+        "recovered using fallback"
+    } else {
+        "could not recover"
+    }
+}
+
 /// Result type for parsing that includes warnings.
 ///
-/// This is returned by the main [`parse`](crate::parse) function and contains
-/// both the successfully parsed puzzle and any warnings that occurred during parsing.
+/// Returned by the verbose parse entry points (for example
+/// [`PuzzleReader::from_file_verbose`](crate::PuzzleReader::from_file_verbose)):
+/// it holds the parsed puzzle alongside any non-fatal [`PuzWarning`]s.
 #[derive(Debug)]
 pub struct ParseResult<T> {
-    /// The successfully parsed puzzle
+    /// The successfully parsed puzzle.
     pub result: T,
-    /// Any warnings that occurred during parsing
+    /// Any warnings that occurred during parsing.
     pub warnings: Vec<PuzWarning>,
 }
 
 impl<T> ParseResult<T> {
-    pub fn new(result: T) -> Self {
-        Self {
-            result,
-            warnings: Vec::new(),
-        }
-    }
-
-    pub fn with_warnings(result: T, warnings: Vec<PuzWarning>) -> Self {
+    pub(crate) fn with_warnings(result: T, warnings: Vec<PuzWarning>) -> Self {
         Self { result, warnings }
-    }
-
-    pub fn add_warning(&mut self, warning: PuzWarning) {
-        self.warnings.push(warning);
     }
 }
 
-/// Errors that can occur when parsing a .puz file.
+/// Errors that can occur when parsing or writing a .puz file.
 ///
-/// These represent critical issues that prevent successful parsing of the puzzle.
-/// Unlike [`PuzWarning`], these errors cause parsing to fail completely.
-#[derive(Debug, Clone, PartialEq)]
+/// These represent critical issues that prevent successful processing. Unlike
+/// [`PuzWarning`], they cause the operation to fail. `PuzError` implements
+/// [`std::error::Error`], so the underlying I/O error is reachable via
+/// [`Error::source`](std::error::Error::source).
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum PuzError {
-    /// The file magic header is invalid
+    /// The file magic header is invalid.
+    #[error(
+        "Invalid .puz file magic header. Expected 'ACROSS&DOWN\\0', found: {found:?}. This file may be corrupted or not a .puz file."
+    )]
     InvalidMagic { found: Vec<u8> },
 
-    /// Checksum validation failed
+    /// Checksum validation failed.
+    #[error(
+        "Checksum validation failed in {context}: expected 0x{expected:04X}, found 0x{found:04X}. The file may be corrupted."
+    )]
     InvalidChecksum {
         expected: u16,
         found: u16,
         context: String,
     },
 
-    /// Puzzle dimensions are invalid
+    /// Puzzle dimensions are invalid.
+    #[error("Invalid puzzle dimensions: {width}x{height}. Dimensions must be between 1 and 255.")]
     InvalidDimensions { width: u8, height: u8 },
 
-    /// Clue count doesn't match expected value
+    /// Clue count doesn't match the expected value.
+    #[error(
+        "Clue count mismatch: expected {expected} clues, found {found}. The file may be corrupted."
+    )]
     InvalidClueCount { expected: u16, found: usize },
 
-    /// Extension section size mismatch
+    /// Extension section size mismatch.
+    #[error(
+        "Extension section '{section}' size mismatch: expected {expected} bytes, found {found}. The section may be corrupted."
+    )]
     SectionSizeMismatch {
         section: String,
         expected: usize,
         found: usize,
     },
 
-    /// Parse error with position context
-    ParseError {
-        message: String,
-        position: Option<u64>,
-        context: String,
-    },
+    /// An I/O error occurred while reading or writing the file.
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
 
-    /// An I/O error occurred while reading the file
-    IoError {
-        message: String,
-        kind: io::ErrorKind,
-        position: Option<u64>,
-    },
+    /// The file contains invalid UTF-8 data.
+    #[error("Invalid UTF-8 data: {0}")]
+    InvalidUtf8(#[from] std::str::Utf8Error),
 
-    /// The file contains invalid UTF-8 data
-    InvalidUtf8 {
-        message: String,
-        position: Option<u64>,
-    },
-
-    /// Required data is missing from the file
-    MissingData {
-        field: String,
-        position: Option<u64>,
-    },
-
-    /// The file version is not supported
+    /// The file version is not supported.
+    #[error("Unsupported .puz file version: '{version}'. Only standard versions are supported.")]
     UnsupportedVersion { version: String },
 
-    /// Grid validation failed
+    /// Grid validation failed.
+    #[error("Invalid puzzle grid: {reason}")]
     InvalidGrid { reason: String },
 
-    /// Clue processing failed
+    /// Clue processing failed.
+    #[error("Invalid clues: {reason}")]
     InvalidClues { reason: String },
 
-    /// A string contains a character that cannot be encoded in Windows-1252
+    /// A string contains a character that cannot be encoded in Windows-1252.
+    #[error(
+        "Cannot encode character {character:?} in {context}: not representable in Windows-1252."
+    )]
     EncodingError { character: char, context: String },
 
-    /// A requested puzzle feature is not supported by the writer
+    /// A requested puzzle feature is not supported by the writer.
+    #[error("Writing is not supported for: {feature}.")]
     UnsupportedFeature { feature: String },
 }
 
-impl fmt::Display for PuzError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PuzError::InvalidMagic { found } => {
-                write!(
-                    f,
-                    "Invalid .puz file magic header. Expected 'ACROSS&DOWN\\0', found: {found:?}. This file may be corrupted or not a .puz file."
-                )
-            }
-            PuzError::InvalidChecksum {
-                expected,
-                found,
-                context,
-            } => {
-                write!(
-                    f,
-                    "Checksum validation failed in {context}: expected 0x{expected:04X}, found 0x{found:04X}. The file may be corrupted."
-                )
-            }
-            PuzError::InvalidDimensions { width, height } => {
-                write!(
-                    f,
-                    "Invalid puzzle dimensions: {width}x{height}. Dimensions must be between 1 and 255."
-                )
-            }
-            PuzError::InvalidClueCount { expected, found } => {
-                write!(
-                    f,
-                    "Clue count mismatch: expected {expected} clues, found {found}. The file may be corrupted."
-                )
-            }
-            PuzError::SectionSizeMismatch {
-                section,
-                expected,
-                found,
-            } => {
-                write!(
-                    f,
-                    "Extension section '{section}' size mismatch: expected {expected} bytes, found {found}. The section may be corrupted."
-                )
-            }
-            PuzError::ParseError {
-                message,
-                position,
-                context,
-            } => match position {
-                Some(pos) => write!(f, "Parse error at position {pos}: {message} ({context})"),
-                None => write!(f, "Parse error: {message} ({context})"),
-            },
-            PuzError::IoError {
-                message,
-                kind,
-                position,
-            } => match position {
-                Some(pos) => write!(f, "I/O error at position {pos}: {message} ({kind:?})"),
-                None => write!(f, "I/O error: {message} ({kind:?})"),
-            },
-            PuzError::InvalidUtf8 { message, position } => match position {
-                Some(pos) => write!(f, "Invalid UTF-8 data at position {pos}: {message}"),
-                None => write!(f, "Invalid UTF-8 data: {message}"),
-            },
-            PuzError::MissingData { field, position } => match position {
-                Some(pos) => write!(f, "Missing required data '{field}' at position {pos}"),
-                None => write!(f, "Missing required data: {field}"),
-            },
-            PuzError::UnsupportedVersion { version } => {
-                write!(
-                    f,
-                    "Unsupported .puz file version: '{version}'. Only standard versions are supported."
-                )
-            }
-            PuzError::InvalidGrid { reason } => {
-                write!(f, "Invalid puzzle grid: {reason}")
-            }
-            PuzError::InvalidClues { reason } => {
-                write!(f, "Invalid clues: {reason}")
-            }
-            PuzError::EncodingError { character, context } => {
-                write!(
-                    f,
-                    "Cannot encode character {character:?} in {context}: not representable in Windows-1252."
-                )
-            }
-            PuzError::UnsupportedFeature { feature } => {
-                write!(f, "Writing is not supported for: {feature}.")
-            }
-        }
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as _;
 
-impl StdError for PuzError {}
-
-impl From<io::Error> for PuzError {
-    fn from(error: io::Error) -> Self {
-        PuzError::IoError {
-            message: format!("I/O operation failed: {error}"),
-            kind: error.kind(),
-            position: None,
-        }
-    }
-}
-
-impl From<std::str::Utf8Error> for PuzError {
-    fn from(error: std::str::Utf8Error) -> Self {
-        PuzError::InvalidUtf8 {
-            message: format!("UTF-8 decoding failed: {error}"),
-            position: None,
-        }
-    }
-}
-
-impl PuzError {
-    /// Add position context to an existing error
-    pub fn with_position(mut self, position: u64) -> Self {
-        match &mut self {
-            PuzError::IoError { position: pos, .. } => *pos = Some(position),
-            PuzError::InvalidUtf8 { position: pos, .. } => *pos = Some(position),
-            PuzError::MissingData { position: pos, .. } => *pos = Some(position),
-            PuzError::ParseError { position: pos, .. } => *pos = Some(position),
-            _ => {} // Other error types don't have position fields
-        }
-        self
+    #[test]
+    fn test_io_error_from_and_source_chain() {
+        let io = io::Error::new(io::ErrorKind::NotFound, "boom");
+        let err: PuzError = io.into();
+        assert!(matches!(err, PuzError::Io(_)));
+        // The originating io::Error is reachable via the error source chain.
+        let source = err.source().expect("Io variant should expose its source");
+        assert_eq!(source.to_string(), "boom");
     }
 
-    /// Add context to an existing error
-    pub fn with_context(self, context: &str) -> Self {
-        match self {
-            PuzError::IoError {
-                message,
-                kind,
-                position,
-            } => PuzError::IoError {
-                message: format!("{context}: {message}"),
-                kind,
-                position,
-            },
-            PuzError::InvalidUtf8 { message, position } => PuzError::InvalidUtf8 {
-                message: format!("{context}: {message}"),
-                position,
-            },
-            PuzError::ParseError {
-                message,
-                position,
-                context: existing_context,
-            } => PuzError::ParseError {
-                message,
-                position,
-                context: format!("{context}: {existing_context}"),
-            },
-            other => other, // For other types, return as-is or convert to ParseError
-        }
+    #[test]
+    fn test_non_io_error_has_no_source() {
+        let err = PuzError::InvalidGrid {
+            reason: "bad".to_string(),
+        };
+        assert!(err.source().is_none());
     }
-}
 
-impl fmt::Display for PuzWarning {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PuzWarning::SkippedExtension { section, reason } => {
-                write!(f, "Skipped extension section '{section}': {reason}")
-            }
-            PuzWarning::EncodingIssue { context, recovered } => {
-                write!(
-                    f,
-                    "Encoding issue in {}: {}",
-                    context,
-                    if *recovered {
-                        "recovered using fallback"
-                    } else {
-                        "could not recover"
-                    }
-                )
-            }
-            PuzWarning::DataRecovery { field, issue } => {
-                write!(f, "Data recovery for '{field}': {issue}")
-            }
-            PuzWarning::ScrambledPuzzle { version } => {
-                write!(
-                    f,
-                    "Puzzle is scrambled (version {version}). Solution may not be readable without descrambling."
-                )
-            }
-            PuzWarning::ChecksumMismatch {
-                context,
-                expected,
-                found,
-            } => {
-                write!(
-                    f,
-                    "Checksum mismatch in {context}: expected 0x{expected:04X}, found 0x{found:04X}. The file may be corrupted."
-                )
-            }
-            PuzWarning::UnbackedGridChar {
-                character,
-                row,
-                col,
-            } => {
-                write!(
-                    f,
-                    "Solution cell ({row}, {col}) has non-standard character '{character}' (U+{code:04X}) with no rebus entry at that position.",
-                    code = *character as u32
-                )
-            }
-            PuzWarning::ExtraClues { slots, provided } => {
-                write!(
-                    f,
-                    "File provided {provided} clue strings but the grid has {slots} word slots; \
-                     the {} extra clue(s) are preserved in Clues::raw.",
-                    provided - slots
-                )
-            }
-        }
+    #[test]
+    fn test_display_messages() {
+        let err = PuzError::InvalidDimensions {
+            width: 0,
+            height: 5,
+        };
+        assert!(err.to_string().contains("0x5"));
+
+        let warn = PuzWarning::ExtraClues {
+            slots: 76,
+            provided: 78,
+        };
+        assert!(warn.to_string().contains("2 extra"));
     }
 }

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -112,71 +112,67 @@ mod writer;
 
 pub use error::{ParseResult, PuzError, PuzWarning};
 pub use puzzle::{Puzzle, PuzzleReader};
-pub use types::*;
+pub use types::{ClueAnswer, ClueSet, Clues, Direction, Extensions, Grid, PuzzleInfo, Rebus};
 
 use std::io::Read;
 use std::path::Path;
 
-/// Parse a .puz file from any source that implements `Read`.
-///
-/// This is the core parsing function that provides full control over error handling
-/// and warnings. Use [`Puzzle::from_file`] for a simpler API when parsing from files.
-///
-/// # Arguments
-///
-/// * `reader` - Any type that implements `Read`, such as a `File` or `&[u8]`
-///
-/// # Returns
-///
-/// Returns a `Result<ParseResult<Puzzle>, PuzError>` containing the parsed puzzle data
-/// along with any warnings, or an error if parsing fails.
+/// Parse a .puz file from any source that implements `Read`, returning the
+/// puzzle and any warnings.
 ///
 /// # Example
 ///
 /// ```rust,no_run
-/// use std::fs::File;
-/// use puz_parse::parse;
+/// use puz_parse::Puzzle;
 ///
-/// let file = File::open("puzzle.puz")?;
-/// let result = parse(file)?;
-/// let puzzle = result.result;
-/// for warning in &result.warnings {
+/// let parsed = Puzzle::reader().from_file_verbose("puzzle.puz")?;
+/// for warning in &parsed.warnings {
 ///     eprintln!("Warning: {}", warning);
 /// }
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), puz_parse::PuzError>(())
 /// ```
+#[deprecated(
+    since = "0.2.0",
+    note = "use `Puzzle::from_reader` (or `Puzzle::reader().from_reader_verbose`) instead"
+)]
 pub fn parse<R: Read>(reader: R) -> Result<ParseResult<Puzzle>, PuzError> {
     parser::parse_puzzle(reader)
 }
 
 /// Parse a .puz file, requiring all stored checksums to match.
 ///
-/// Unlike [`parse`], which records checksum mismatches as
-/// [`PuzWarning::ChecksumMismatch`] and continues, this returns
-/// [`PuzError::InvalidChecksum`] on the first mismatch. Use this when you need
-/// to reject files whose integrity checks fail.
+/// Returns [`PuzError::InvalidChecksum`] on the first mismatch instead of
+/// recording a warning.
+#[deprecated(
+    since = "0.2.0",
+    note = "use `Puzzle::reader().strict(true).from_reader_verbose(..)` instead"
+)]
 pub fn parse_strict<R: Read>(reader: R) -> Result<ParseResult<Puzzle>, PuzError> {
     parser::parse_puzzle_strict(reader)
 }
 
 /// Validate the checksums of a .puz file without returning the puzzle.
 ///
-/// Returns `Ok(())` if all stored checksums match the recomputed values, or
+/// Returns `Ok(())` if all stored checksums match, or
 /// [`PuzError::InvalidChecksum`] on the first mismatch (or a parse error if the
 /// data is malformed).
 ///
 /// # Example
 ///
 /// ```rust,no_run
-/// use puz_parse::validate_bytes;
+/// use puz_parse::Puzzle;
 ///
 /// let data = std::fs::read("puzzle.puz")?;
-/// match validate_bytes(&data) {
-///     Ok(()) => println!("checksums valid"),
+/// match Puzzle::reader().strict(true).from_bytes(&data) {
+///     Ok(_) => println!("checksums valid"),
 ///     Err(e) => eprintln!("invalid: {e}"),
 /// }
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), puz_parse::PuzError>(())
 /// ```
+#[deprecated(
+    since = "0.2.0",
+    note = "use `Puzzle::reader().strict(true).from_bytes(..)` instead"
+)]
 pub fn validate_bytes(data: &[u8]) -> Result<(), PuzError> {
     parser::parse_puzzle_strict(data).map(|_| ())
 }
@@ -184,7 +180,7 @@ pub fn validate_bytes(data: &[u8]) -> Result<(), PuzError> {
 /// Parse a .puz file from a file path.
 ///
 /// This is a convenience function that handles file opening and returns just the
-/// puzzle data. Warnings are discarded. Use [`parse`] for full control.
+/// puzzle data. Warnings are discarded. Use [`Puzzle::from_file`] for full control.
 ///
 /// # Arguments
 ///
@@ -205,14 +201,7 @@ pub fn validate_bytes(data: &[u8]) -> Result<(), PuzError> {
 /// ```
 #[deprecated(since = "0.2.0", note = "use `Puzzle::from_file` instead")]
 pub fn parse_file<P: AsRef<Path>>(path: P) -> Result<Puzzle, PuzError> {
-    let file = std::fs::File::open(path.as_ref()).map_err(|e| PuzError::IoError {
-        message: format!("Failed to open file: {e}"),
-        kind: e.kind(),
-        position: None,
-    })?;
-
-    let result = parse(file)?;
-    Ok(result.result)
+    Puzzle::from_file(path)
 }
 
 /// Parse a .puz file from a byte slice.
@@ -238,8 +227,7 @@ pub fn parse_file<P: AsRef<Path>>(path: P) -> Result<Puzzle, PuzError> {
 /// ```
 #[deprecated(since = "0.2.0", note = "use `Puzzle::from_bytes` instead")]
 pub fn parse_bytes(data: &[u8]) -> Result<Puzzle, PuzError> {
-    let result = parse(data)?;
-    Ok(result.result)
+    Puzzle::from_bytes(data)
 }
 
 /// Serialize a puzzle to an in-memory `.puz` byte buffer.
@@ -263,11 +251,8 @@ pub fn to_bytes(puzzle: &Puzzle) -> Result<Vec<u8>, PuzError> {
 /// Write a puzzle to any type that implements `Write`.
 pub fn write<W: std::io::Write>(puzzle: &Puzzle, mut writer: W) -> Result<(), PuzError> {
     let bytes = to_bytes(puzzle)?;
-    writer.write_all(&bytes).map_err(|e| PuzError::IoError {
-        message: format!("Failed to write puzzle: {e}"),
-        kind: e.kind(),
-        position: None,
-    })
+    writer.write_all(&bytes)?;
+    Ok(())
 }
 
 /// Write a puzzle to a file path.
@@ -282,10 +267,6 @@ pub fn write<W: std::io::Write>(puzzle: &Puzzle, mut writer: W) -> Result<(), Pu
 /// # Ok::<(), puz_parse::PuzError>(())
 /// ```
 pub fn write_file<P: AsRef<Path>>(puzzle: &Puzzle, path: P) -> Result<(), PuzError> {
-    let file = std::fs::File::create(path.as_ref()).map_err(|e| PuzError::IoError {
-        message: format!("Failed to create file: {e}"),
-        kind: e.kind(),
-        position: None,
-    })?;
+    let file = std::fs::File::create(path.as_ref())?;
     write(puzzle, file)
 }

--- a/parse/src/parser/grids.rs
+++ b/parse/src/parser/grids.rs
@@ -383,7 +383,7 @@ mod tests {
         let result = parse_grids(&mut reader, width, height);
 
         assert!(result.is_err());
-        matches!(result.unwrap_err(), PuzError::IoError { .. });
+        matches!(result.unwrap_err(), PuzError::Io(_));
     }
 
     /// Test grid parsing with consistency validation failure

--- a/parse/src/parser/header.rs
+++ b/parse/src/parser/header.rs
@@ -321,7 +321,7 @@ mod tests {
         let result = parse_header(&mut reader);
 
         assert!(result.is_err());
-        matches!(result.unwrap_err(), PuzError::IoError { .. });
+        matches!(result.unwrap_err(), PuzError::Io(_));
     }
 
     /// Test header parsing with Windows-1252 encoded version strings

--- a/parse/src/parser/io.rs
+++ b/parse/src/parser/io.rs
@@ -160,7 +160,7 @@ mod tests {
 
         assert!(result.is_err());
         // Should get an IO error due to incomplete read
-        matches!(result.unwrap_err(), PuzError::IoError { .. });
+        matches!(result.unwrap_err(), PuzError::Io(_));
     }
 
     /// Test skip_bytes function with various byte counts
@@ -193,7 +193,7 @@ mod tests {
         // Try to skip more bytes than available
         let result = skip_bytes(&mut reader, 5);
         assert!(result.is_err());
-        matches!(result.unwrap_err(), PuzError::IoError { .. });
+        matches!(result.unwrap_err(), PuzError::Io(_));
     }
 
     /// Test reading single bytes
@@ -264,7 +264,7 @@ mod tests {
 
         let result = read_string_until_nul_raw(&mut reader);
         assert!(result.is_err());
-        matches!(result.unwrap_err(), PuzError::IoError { .. });
+        matches!(result.unwrap_err(), PuzError::Io(_));
     }
 
     /// Test finding sections in extension data

--- a/parse/src/puzzle.rs
+++ b/parse/src/puzzle.rs
@@ -396,11 +396,9 @@ impl PuzzleReader {
     }
 
     fn open(path: &Path) -> Result<std::fs::File, PuzError> {
-        std::fs::File::open(path).map_err(|e| PuzError::IoError {
-            message: format!("Failed to open file: {e}"),
-            kind: e.kind(),
-            position: None,
-        })
+        // `io::Error` converts into `PuzError::Io` via `#[from]`, preserving the
+        // original error as the source.
+        Ok(std::fs::File::open(path)?)
     }
 
     /// Parse from a file path, returning the puzzle and its warnings.

--- a/parse/src/types.rs
+++ b/parse/src/types.rs
@@ -28,11 +28,15 @@ pub struct PuzzleInfo {
 
 /// The puzzle grid containing both solution and blank layouts.
 ///
-/// The grid is represented as vectors of strings, where each string is a row.
-/// Characters represent:
+/// Each grid is a vector of rows, one `String` per row. Characters represent:
 /// - `.` = black/blocked square
-/// - `-` = empty square (in blank grid)
-/// - Letters/numbers = cell content
+/// - `-` = empty square (in the blank grid)
+/// - letters/numbers = cell content
+///
+/// The fields are public, but [`width`](Self::width), [`height`](Self::height),
+/// [`solution_cell`](Self::solution_cell), [`blank_cell`](Self::blank_cell), and
+/// [`is_black`](Self::is_black) are the safe way to read cells: they count cells
+/// (not bytes) and bounds-check.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
 pub struct Grid {
@@ -40,6 +44,66 @@ pub struct Grid {
     pub blank: Vec<String>,
     /// The solution grid with all answers filled in
     pub solution: Vec<String>,
+}
+
+impl Grid {
+    /// The number of rows (grid height).
+    pub fn height(&self) -> usize {
+        self.solution.len()
+    }
+
+    /// The number of columns (grid width), measured in cells.
+    ///
+    /// A cell is one character. This counts `chars`, not bytes, so a row with a
+    /// multi-byte cell (some puzzles store a high byte as a rebus marker) still
+    /// reports the correct width.
+    pub fn width(&self) -> usize {
+        self.solution
+            .first()
+            .map(|r| r.chars().count())
+            .unwrap_or(0)
+    }
+
+    /// The solution cell at `(row, col)`, or `None` if out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use puz_parse::Puzzle;
+    ///
+    /// let puzzle = Puzzle::new().grid(["AB.", "CDE"]);
+    /// assert_eq!(puzzle.grid.solution_cell(0, 0), Some('A'));
+    /// assert_eq!(puzzle.grid.solution_cell(0, 2), Some('.')); // black square
+    /// assert_eq!(puzzle.grid.solution_cell(9, 9), None);
+    /// ```
+    pub fn solution_cell(&self, row: usize, col: usize) -> Option<char> {
+        cell_at(&self.solution, row, col)
+    }
+
+    /// The blank-grid cell at `(row, col)`, or `None` if out of bounds.
+    pub fn blank_cell(&self, row: usize, col: usize) -> Option<char> {
+        cell_at(&self.blank, row, col)
+    }
+
+    /// Whether the cell at `(row, col)` is a black square (`.`).
+    ///
+    /// Out-of-bounds cells are treated as not black.
+    pub fn is_black(&self, row: usize, col: usize) -> bool {
+        self.solution_cell(row, col) == Some('.')
+    }
+}
+
+/// Read the character at `(row, col)` of a row-per-string grid.
+///
+/// Fast-paths the all-ASCII case with byte indexing (the common `.puz` grid),
+/// falling back to a `chars()` scan only for a non-ASCII row.
+fn cell_at(rows: &[String], row: usize, col: usize) -> Option<char> {
+    let row = rows.get(row)?;
+    if row.is_ascii() {
+        row.as_bytes().get(col).map(|&b| b as char)
+    } else {
+        row.chars().nth(col)
+    }
 }
 
 /// The direction of a clue or word: across or down.
@@ -387,5 +451,68 @@ mod tests {
         assert_eq!(set.get(1), Some("one"));
         assert_eq!(set.as_map().len(), 1);
         assert_eq!(set.into_inner().get(&1).map(String::as_str), Some("one"));
+    }
+
+    fn sample_grid() -> Grid {
+        Grid {
+            solution: vec!["AB.".to_string(), "CDE".to_string()],
+            blank: vec!["--.".to_string(), "---".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_grid_dimensions() {
+        let g = sample_grid();
+        assert_eq!(g.width(), 3);
+        assert_eq!(g.height(), 2);
+    }
+
+    #[test]
+    fn test_grid_dimensions_empty() {
+        let g = Grid {
+            solution: Vec::new(),
+            blank: Vec::new(),
+        };
+        assert_eq!(g.width(), 0);
+        assert_eq!(g.height(), 0);
+    }
+
+    #[test]
+    fn test_grid_cell_access() {
+        let g = sample_grid();
+        assert_eq!(g.solution_cell(0, 0), Some('A'));
+        assert_eq!(g.solution_cell(0, 2), Some('.'));
+        assert_eq!(g.solution_cell(1, 2), Some('E'));
+        assert_eq!(g.blank_cell(0, 0), Some('-'));
+        assert_eq!(g.blank_cell(0, 2), Some('.'));
+    }
+
+    #[test]
+    fn test_grid_cell_out_of_bounds() {
+        let g = sample_grid();
+        assert_eq!(g.solution_cell(2, 0), None); // row past height
+        assert_eq!(g.solution_cell(0, 3), None); // col past width
+        assert_eq!(g.blank_cell(9, 9), None);
+    }
+
+    #[test]
+    fn test_grid_is_black() {
+        let g = sample_grid();
+        assert!(g.is_black(0, 2));
+        assert!(!g.is_black(0, 0));
+        assert!(!g.is_black(5, 5)); // out of bounds is not black
+    }
+
+    #[test]
+    fn test_grid_cell_non_ascii_row() {
+        // A high byte decodes to a multi-byte char; width must count cells, and
+        // cell access must return the char, not a byte slice.
+        let g = Grid {
+            solution: vec!["\u{00C2}B".to_string()],
+            blank: vec!["--".to_string()],
+        };
+        assert_eq!(g.width(), 2);
+        assert_eq!(g.solution_cell(0, 0), Some('\u{00C2}'));
+        assert_eq!(g.solution_cell(0, 1), Some('B'));
     }
 }

--- a/parse/src/writer/mod.rs
+++ b/parse/src/writer/mod.rs
@@ -208,7 +208,10 @@ mod tests {
 
         // The file's stored checksums are over the emitted ':' bytes, and the
         // verifier must checksum the same bytes, so strict validation passes.
-        crate::validate_bytes(&bytes).expect("diagramless file must pass strict validation");
+        Puzzle::reader()
+            .strict(true)
+            .from_bytes(&bytes)
+            .expect("diagramless file must pass strict validation");
 
         let reparsed = Puzzle::from_bytes(&bytes).unwrap();
         assert!(reparsed.info.is_diagramless);
@@ -445,9 +448,12 @@ mod tests {
         // recomputation. This is the non-circular integrity check: the parser
         // recomputes from puzzle data, not from how the writer built the bytes.
         let bytes = to_bytes(&sample_puzzle()).unwrap();
-        crate::validate_bytes(&bytes).expect("written file should validate");
+        Puzzle::reader()
+            .strict(true)
+            .from_bytes(&bytes)
+            .expect("written file should validate");
         // lenient parse should emit no checksum-mismatch warning
-        let result = crate::parse(&bytes[..]).unwrap();
+        let result = Puzzle::reader().from_bytes_verbose(&bytes).unwrap();
         assert!(
             !result
                 .warnings
@@ -464,10 +470,13 @@ mod tests {
         let mut bytes = to_bytes(&sample_puzzle()).unwrap();
         bytes[0x00] ^= 0xFF;
 
-        let err = crate::validate_bytes(&bytes).unwrap_err();
+        let err = Puzzle::reader()
+            .strict(true)
+            .from_bytes(&bytes)
+            .unwrap_err();
         assert!(matches!(err, PuzError::InvalidChecksum { .. }));
 
-        let result = crate::parse(&bytes[..]).unwrap();
+        let result = Puzzle::reader().from_bytes_verbose(&bytes).unwrap();
         assert!(
             result
                 .warnings
@@ -482,7 +491,10 @@ mod tests {
         let mut bytes = to_bytes(&sample_puzzle()).unwrap();
         bytes[0x0E] ^= 0xFF;
         assert!(matches!(
-            crate::validate_bytes(&bytes).unwrap_err(),
+            Puzzle::reader()
+                .strict(true)
+                .from_bytes(&bytes)
+                .unwrap_err(),
             PuzError::InvalidChecksum { .. }
         ));
     }
@@ -492,7 +504,10 @@ mod tests {
         let mut bytes = to_bytes(&sample_puzzle()).unwrap();
         bytes[0x10] ^= 0xFF;
         assert!(matches!(
-            crate::validate_bytes(&bytes).unwrap_err(),
+            Puzzle::reader()
+                .strict(true)
+                .from_bytes(&bytes)
+                .unwrap_err(),
             PuzError::InvalidChecksum { .. }
         ));
     }


### PR DESCRIPTION
A focused cleanup of the `puz-parse` library's public API, driven by an API
audit. The goal is a clearer, more idiomatic surface for external consumers.

## Changes

**Explicit re-exports (was a glob).** Replaced `pub use types::*` with a named
list. The public surface is now visible at the re-export site and can't grow by
accident when a new `pub` item is added to `types.rs`.

**`Grid` accessors.** Added `width()`, `height()`, `solution_cell(row, col)`,
`blank_cell(row, col)`, and `is_black(row, col)`. Consumers no longer have to
hand-index `Vec<String>` and call `.chars().nth(col)`, which is easy to get
wrong with multi-byte cells. Cell access counts cells, not bytes, and
bounds-checks.

**Error types rebuilt on `thiserror`.** `PuzError` and `PuzWarning` now derive
`Display` via `#[error(...)]` instead of a hand-written `impl`. The I/O variant
wraps `io::Error` directly (`Io(#[from] io::Error)`), so:
- `From<io::Error>` and `?` conversion are automatic, and
- the original error is reachable through
  [`Error::source`](https://doc.rust-lang.org/std/error/trait.Error.html#method.source),
  which was previously lost.

Also removed dead variants (`ParseError`, `MissingData`) and the unused
`PuzError::with_position` / `with_context` helpers, and made the `ParseResult`
constructors `pub(crate)` (internal machinery).

**Deprecated the redundant free parse functions.** `parse`, `parse_strict`, and
`validate_bytes` are now `#[deprecated]` in favor of `Puzzle::from_file` /
`from_bytes` / `from_reader` and `Puzzle::reader()`. Internal callers were
migrated, so there are no deprecation warnings in-tree. `parse_file` /
`parse_bytes` remain deprecated as before.

## Breaking changes (pre-1.0)

- `PuzError` no longer derives `Clone` or `PartialEq` (it can carry a non-`Clone`,
  non-`PartialEq` `io::Error` source). Match on the variant instead of comparing.
- `PuzError::IoError { .. }` is now `PuzError::Io(io::Error)`; the dead
  `ParseError` and `MissingData` variants are removed.
- `PuzError::with_position` / `with_context` are removed.

## Dependencies

Adds `thiserror` (2.0) to `puz-parse`. It supports the library's 1.85 MSRV and
resolves under `-Z minimal-versions`.

## Verification

- 180 unit tests + 23 doctests pass
- `cargo fmt --all -- --check`, clippy (all targets, `--no-default-features`,
  `--features json`) clean
- `cargo doc` with `-D warnings` clean
- MSRV: library on 1.85, workspace on 1.88
- minimal-versions resolves and builds